### PR TITLE
Update addcomputer.py

### DIFF
--- a/lib/scripts/addcomputer.py
+++ b/lib/scripts/addcomputer.py
@@ -44,7 +44,7 @@ class AddComputerSAMR:
 
 
         if self.__hashes is not None:
-            self.__lmhash, self.__nthash = self.hashes.split(':')
+            self.__lmhash, self.__nthash = self.__hashes.split(':')
 
         if self.__computerPassword is None:
             self.__computerPassword = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(32))


### PR DESCRIPTION
When using NTLM hash for authentication when using http/auto, the NTLM hash is not properly parsed within the AddComputerSAMR Class. This PR fixes that.
