### PR TITLE
Site server profiling for DP role

### DIFF
--- a/lib/attacks/smb.py
+++ b/lib/attacks/smb.py
@@ -208,6 +208,8 @@ class SMB:
                     if "SMS Site" in remark:
                         distp = True
                         site_code = (remark.split(" ")[2])
+                    elif "ConfigMgr Site Server" in remark:
+                        distp = True
                 except:
                     distp = False
             if "REMINST" in shares_dict:


### PR DESCRIPTION
Added a quick fix for this issue -- now adding site servers to the computers table when the System Management ACL gets parsed. smb enum doesn't deduplicate, so a site server that is a MP will get scanned 3 times at the moment.


```
(venv) testsubject1@sphere1:/tmp/sccmhunter$ python3 ./sccmhunter.py find -dc-ip 10.1.0.100 -d APERTURE.LOCAL -u TESTSUBJECT4 -p BlackMesa004 -debug
SCCMHunter v1.0.5 by @garrfoster
[22:41:03] DEBUG    [*] Database ready.                                                                                                                                                                          
[22:41:03] DEBUG    [+] Bind successful ldap://10.1.0.100:389 - cleartext                                                                                                                                        
[22:41:03] INFO     [*] Checking for System Management Container.                                                                                                                                                
[22:41:03] INFO     [+] Found System Management Container. Parsing DACL.                                                                                                                                         
[22:41:03] DEBUG    [+] Found host: atlas.aperture.local                                                                                                                                                         
[22:41:03] INFO     [+] Found 1 computers with Full Control ACE                                                                                                                                                  
[22:41:03] INFO     [*] Querying LDAP for published Sites and Management Points                                                                                                                                  
[22:41:03] INFO     [+] Found 1 Management Points in LDAP.                                                                                                                                                       
[22:41:03] DEBUG    [*] Skipping already known host: atlas.aperture.local                                                                                                                                        
[22:41:03] INFO     [*] Searching LDAP for anything containing the strings 'SCCM' or 'MECM'                                                                                                                      
[22:41:03] INFO     [+] Found 2 principals that contain the string 'SCCM' or 'MECM'.                                                                                                                             
[22:41:03] DEBUG    [+] Found user: SCCMADMIN                                                                                                                                                                    
[22:41:03] DEBUG    [+] Found group: SCCM Full Administrator                                                                                                                                                     
[22:41:03] INFO     Site Servers Table                                                                                                                                                                           
[22:41:03] INFO     +----------------------+------------+-------+-----------------+--------------+---------------+----------+---------+                                                                          
                    | Hostname             | SiteCode   | CAS   | SigningStatus   | SiteServer   | SMSProvider   | Config   | MSSQL   |                                                                          
                    +======================+============+=======+=================+==============+===============+==========+=========+                                                                          
                    | atlas.aperture.local |            |       |                 | True         |               |          |         |                                                                          
                    +----------------------+------------+-------+-----------------+--------------+---------------+----------+---------+                                                                          
[22:41:03] INFO     Management Points Table                                                                                                                                                                      
[22:41:03] INFO     +----------------------+------------+-----------------+                                                                                                                                      
                    | Hostname             | SiteCode   | SigningStatus   |                                                                                                                                      
                    +======================+============+=================+                                                                                                                                      
                    | atlas.aperture.local | PS1        |                 |                                                                                                                                      
                    +----------------------+------------+-----------------+                                                                                                                                      
[22:41:03] INFO     Computers Table                                                                                                                                                                              
[22:41:03] INFO     +----------------------+------------+-----------------+--------------+-------------------+---------------------+---------------+--------+---------+                                          
                    | Hostname             | SiteCode   | SigningStatus   | SiteServer   | ManagementPoint   | DistributionPoint   | SMSProvider   | WSUS   | MSSQL   |                                          
                    +======================+============+=================+==============+===================+=====================+===============+========+=========+                                          
                    | atlas.aperture.local |            |                 |              |                   |                     |               |        |         |                                          
                    +----------------------+------------+-----------------+--------------+-------------------+---------------------+---------------+--------+---------+                                          
[22:41:03] INFO     Users Table                                                                                                                                                                                  
[22:41:03] INFO     +-----------+-----------+------------------+------------------------+---------------+                                                                                                        
                    | cn        | name      | sAMAAccontName   | servicePrincipalName   | description   |                                                                                                        
                    +===========+===========+==================+========================+===============+                                                                                                        
                    | SCCMADMIN | SCCMADMIN | SCCMADMIN        |                        |               |                                                                                                        
                    +-----------+-----------+------------------+------------------------+---------------+                                                                                                        
[22:41:03] INFO     Groups Table                                                                                                                                                                                 
[22:41:03] INFO     +-------------------------+-------------------------+-------------------------+--------------------------------------------+---------------+                                                 
                    | cn                      | name                    | sAMAAccontName          | member                                     | description   |                                                 
                    +=========================+=========================+=========================+============================================+===============+                                                 
                    | SCCM Full Administrator | SCCM Full Administrator | SCCM Full Administrator | CN=SCCMADMIN,CN=Users,DC=aperture,DC=local |               |                                                 
                    +-------------------------+-------------------------+-------------------------+--------------------------------------------+---------------+                                                 
(venv) testsubject1@sphere1:/tmp/sccmhunter$ python3 ./sccmhunter.py smb -dc-ip 10.1.0.100 -d APERTURE.LOCAL -u TESTSUBJECT4 -p BlackMesa004 -debug
SCCMHunter v1.0.5 by @garrfoster
[22:41:06] INFO     Profiling 1 site servers.                                                                                                                                                                    
[22:41:06] DEBUG    [+] Connected to smb://atlas.aperture.local:445                                                                                                                                              
[22:41:07] INFO     [*] Searching atlas.aperture.local for PXEBoot variables files.                                                                                                                              
[22:41:07] DEBUG    [+] Found \\atlas.aperture.local\REMINST\SMSTemp\2024.08.07.16.43.39.0001.{54BE8772-01EA-44D6-82ED-01504D47EE24}.boot.var                                                                    
[22:41:07] INFO     [+] Results saved to /home/testsubject1/.sccmhunter/logs/smbhunter.log                                                                                                                       
[22:41:12] DEBUG    [-] timed out                                                                                                                                                                                
[22:41:12] INFO     [+] Finished profiling Site Servers.                                                                                                                                                         
[22:41:12] INFO     +----------------------+------------+-------+-----------------+--------------+---------------+----------+---------+                                                                          
                    | Hostname             | SiteCode   | CAS   | SigningStatus   | SiteServer   | SMSProvider   | Config   | MSSQL   |                                                                          
                    +======================+============+=======+=================+==============+===============+==========+=========+                                                                          
                    | atlas.aperture.local | PS1        | False | False           | True         | True          | Active   | False   |                                                                          
                    +----------------------+------------+-------+-----------------+--------------+---------------+----------+---------+                                                                          
[22:41:12] INFO     Profiling 1 management points.                                                                                                                                                               
[22:41:12] DEBUG    [+] Connected to smb://atlas.aperture.local:445                                                                                                                                              
[22:41:12] INFO     [*] Searching atlas.aperture.local for PXEBoot variables files.                                                                                                                              
[22:41:12] DEBUG    [+] Found \\atlas.aperture.local\REMINST\SMSTemp\2024.08.07.16.43.39.0001.{54BE8772-01EA-44D6-82ED-01504D47EE24}.boot.var                                                                    
[22:41:12] INFO     [+] Results saved to /home/testsubject1/.sccmhunter/logs/smbhunter.log                                                                                                                       
[22:41:12] INFO     [+] Finished profiling Management Points.                                                                                                                                                    
[22:41:12] INFO     +----------------------+------------+-----------------+                                                                                                                                      
                    | Hostname             | SiteCode   | SigningStatus   |                                                                                                                                      
                    +======================+============+=================+                                                                                                                                      
                    | atlas.aperture.local | PS1        | False           |                                                                                                                                      
                    +----------------------+------------+-----------------+                                                                                                                                      
[22:41:12] INFO     Profiling 1 computers.                                                                                                                                                                       
[22:41:12] DEBUG    [+] Connected to smb://atlas.aperture.local:445                                                                                                                                              
[22:41:17] DEBUG    [-] timed out                                                                                                                                                                                
[22:41:17] INFO     [*] Searching atlas.aperture.local for PXEBoot variables files.                                                                                                                              
[22:41:17] DEBUG    [+] Found \\atlas.aperture.local\REMINST\SMSTemp\2024.08.07.16.43.39.0001.{54BE8772-01EA-44D6-82ED-01504D47EE24}.boot.var                                                                    
[22:41:17] INFO     [+] Results saved to /home/testsubject1/.sccmhunter/logs/smbhunter.log                                                                                                                       
[22:41:17] INFO     [+] Finished profiling all discovered computers.                                                                                                                                             
[22:41:17] INFO     +----------------------+------------+-----------------+--------------+-------------------+---------------------+---------------+--------+---------+                                          
                    | Hostname             | SiteCode   | SigningStatus   | SiteServer   | ManagementPoint   | DistributionPoint   | SMSProvider   | WSUS   | MSSQL   |                                          
                    +======================+============+=================+==============+===================+=====================+===============+========+=========+                                          
                    | atlas.aperture.local | PS1        | False           | True         | True              | True                | True          | False  | False   |                                          
                    +----------------------+------------+-----------------+--------------+-------------------+---------------------+---------------+--------+---------+       
```
