### PR TITLE
Make sure to close open files before renaming in smb.py

### DIFF
--- a/lib/attacks/smb.py
+++ b/lib/attacks/smb.py
@@ -286,13 +286,13 @@ class SMB:
                         logger.debug(f"[+] Found {full_path}")
                         if self.save:
                             file_name = shared_file.get_longname()
-                            fh = open(ntpath.basename(file_name), 'wb')
-                            path = f"SMSTemp//{file_name}"
-                            try:
-                                conn.getFile(shareName="REMINST",pathName = path, callback=fh.write)
-                                downloaded.append(file_name)
-                            except Exception as e:
-                                logger.info(f"[-] {e}")
+                            with open(ntpath.basename(file_name), 'wb') as fh:
+                                path = f"SMSTemp//{file_name}"
+                                try:
+                                    conn.getFile(shareName="REMINST",pathName = path, callback=fh.write)
+                                    downloaded.append(file_name)
+                                except Exception as e:
+                                    logger.info(f"[-] {e}")
             except Exception as e:
                 logger.debug(e)
         conn.logoff()


### PR DESCRIPTION
Currently the code tries to move a file that isn't closed properly. At least on Windows that breaks stuff, so wrapping it in a context manager fixes the problem.