### PR TITLE
requirements.txt installation so sccmhunter can be installed with pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ pip3 install -r requirements.txt
 python3 sccmhunter.py -h
 ```
 
+`pipx` can also be used to install globally
+```
+
+pipx install git+https://github.com/garrettfoster13/sccmhunter/
+```
+
 # References
 Huge thanks to the below for all their research and hard work and 
 <br>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup
 
+with open('requirements.txt', 'r', encoding='utf-8') as fin:
+  requirements = [i.strip() for i in fin.readlines()]
+
 setup(
   name='sccmhunter',
+  install_requires=requirements,
   scripts = ['sccmhunter.py'],
 )


### PR DESCRIPTION
If installing with `pipx` currently (`pipx install git+https://github.com/garrettfoster13/sccmhunter/`), an error occurs, as the requirements aren't installed automatically

![image](https://github.com/user-attachments/assets/ec8eddcf-b84c-4179-95f5-827e15f1b4d9)

This change reads the requirements.txt file and installs it automatically in `setup.py`

![image](https://github.com/user-attachments/assets/3bfcf5b1-4d1e-466b-9140-60ac1b3feb82)
