### PR TITLE
Fix for check_siteservers

### DIFF
--- a/lib/attacks/smb.py
+++ b/lib/attacks/smb.py
@@ -230,7 +230,7 @@ class SMB:
 
             if "SMS_SITE" in shares_dict:
                 try:
-                    remark = shares_dict.get('SMS_DP$', '')  
+                    remark = shares_dict.get('SMS_DP$', '')
                     if 'ConfigMgr Site Server' in remark:
                         siteserv = True
                     sc = shares_dict.get("SMS_SITE", '')
@@ -253,10 +253,17 @@ class SMB:
                     wdspxe = True
                 if "RemoteInstallation" in remark:
                     sccmpxe = True
-                check = conn.listPath(shareName="REMINST", path="//*")
-                for i in check:
-                    if i.get_longname() == "SMSTemp":
-                        pxe_boot_servers.append(server)
+                try:
+                    check = conn.listPath(shareName="REMINST", path="//*")
+                    for i in check:
+                        if i.get_longname() == "SMSTemp":
+                            pxe_boot_servers.append(server)
+
+                except SessionError as e:
+                    if "STATUS_ACCESS_DENIED" in str(e):
+                        logger.info("[!] Access Denied to the REMINST share.")
+                    else:
+                        logger.info("[!] SMB session error: {e}")
 
             if "WsusContent" in shares_dict:
                 wsus = True


### PR DESCRIPTION
When using the smb module, I ran into the below error when the REMINST share was denied. I added a try block to prevent the script from totally erroring out when this happens. I'm not sure how common smb errors are with this share.


![2025-02-05_19-22-04](https://github.com/user-attachments/assets/218f2378-c978-429d-ae0c-f6b296981b0a)
