### PR TITLE
Fix bug with ldap ccache

### DIFF
--- a/lib/ldap.py
+++ b/lib/ldap.py
@@ -120,6 +120,8 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     if useCache:
         try:
             ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
+            if ccache is None:
+                raise Exception('CCache file is not found. Skipping...')
         except Exception as e:
             # No cache present
             logger.warning(e)


### PR DESCRIPTION
It looks like there is an error in the ldap code when it tries to load a ccache that is not found.

In the `loadFile()` function it just logs a warning and returns none if no cache is found, but the code in ldap is only built to handle the Exception that might be raised, not a `None` return value. If the function returns `None` the subsequent calls will error because of calling functions on a nonexistent cache object.

This should be a simple fix, there are a couple ways to do it but I figured the easiest was to just raise an exception if the cache is not found. The error message is just copied from the underlying function call.

Edit:
This seems to actually be an issue on this repository already - [link](https://github.com/garrettfoster13/sccmhunter/issues/83)