### PR TITLE
List and Delete Scripts

### DIFF
--- a/lib/attacks/cmpivot.py
+++ b/lib/attacks/cmpivot.py
@@ -139,6 +139,19 @@ class SHELL(cmd2.Cmd):
         scriptpath = option[0]
         self.script.run(device=self.device, optional_target=scriptpath)
 
+    @cmd2.with_category(PE)
+    def do_list_scripts(self, arg):
+        """List scripts. """
+        self.script.list_scripts()
+
+    @cmd2.with_category(PE)
+    def do_delete_script(self, arg):
+        """Delete a script from the SCCM server.    delete_script (GUID)"""
+        option = arg.split(' ')
+        guid = option[0]
+        self.script.delete_script(guid)
+
+
 # ############
 # CMPivot Backdoor Section
 # Backdoor existing CMPivot script with your own

--- a/lib/scripts/runscript.py
+++ b/lib/scripts/runscript.py
@@ -171,15 +171,34 @@ Do-Delete
         except ValueError:
             return
         
-    def delete_script(self):
-        url = f"https://{self.target}/AdminService/wmi/SMS_Scripts/{self.guid}"
+    def delete_script(self, guid=None):
+        if guid == None:
+            guid = self.guid
+        url = f"https://{self.target}/AdminService/wmi/SMS_Scripts/{guid}"
 
         try:
             r = requests.delete(f"{url}",
                                 auth=HttpNtlmAuth(self.username, self.password),
                                 verify=False,headers=self.headers)
             if r.status_code == 204:
-                logger.info(f"[+] Script with GUID {self.guid} deleted.")
+                logger.info(f"[+] Script with GUID {guid} deleted.")
+        except Exception as e:
+                logger.info(e)
+
+    def list_scripts(self):
+        url = f"https://{self.target}/AdminService/wmi/SMS_Scripts?$select=ScriptName,ScriptDescription,ScriptGuid,Author,ApprovalState,Approver"
+
+        try:
+            r = requests.get(f"{url}",
+                                auth=HttpNtlmAuth(self.username, self.password),
+                                verify=False,headers=self.headers)
+            if r.status_code == 200:
+                logger.info(f"[+] Retrieved existing scripts.")
+                data = r.json()
+                if isinstance(data['value'], list):
+                    tb = dp.DataFrame(data['value'])
+                    result = tabulate(tb, showindex=False, headers=tb.columns, tablefmt='grid')
+                    logger.info(result)
         except Exception as e:
                 logger.info(e)
 


### PR DESCRIPTION
This is just a basic addition of listing existing scripts and the option to delete them via GUID. We needed this functionality in an engagement so I thought maybe its worth to merge it upstream. One example is, when the program fails during a script run, the script is currently not automatically removed afterwards. Or maybe there is an existing script that you want to run. I did not quite know where the additions would fit the best, feel free to close the PR and put it to a more sensible location.