### PR TITLE
Optional Powershell Hook and Script OPSEC Commands

### DIFF
--- a/lib/attacks/admin.py
+++ b/lib/attacks/admin.py
@@ -16,13 +16,14 @@ class SHELL(cmd2.Cmd):
     DB = "Database Commands"
     IN = "Interface Commands"
     CE = "Credential Extraction Commands"
+    OPSEC = "Opsec Configuration Commands"
     hidden = ["alias", "help", "macro", "run_pyscript", "set", "shortcuts", "edit", "history", "quit", "run_script", "shell", "_relative_run_script", "eof"]
     
 
-    def __init__(self, username, password, kerberos, domain, kdc, target, logs_dir, auser, apassword):
+    def __init__(self, username, password, kerberos, domain, kdc, target, logs_dir, auser, apassword, ps_transform=None):
         #initialize plugins
         self.pivot = CMPIVOT(username=username, password=password, target = target,  kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir = logs_dir)
-        self.script = SMSSCRIPTS(username=username, password=password, target = target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir = logs_dir, auser=auser, apassword=apassword)
+        self.script = SMSSCRIPTS(username=username, password=password, target = target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir = logs_dir, auser=auser, apassword=apassword, ps_transform=ps_transform)
         self.admin = ADD_ADMIN(username=username, password=password,target_ip=target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir=logs_dir)
         self.db = DATABASE(username=username, password=password,url=target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir=logs_dir)
         self.application = SMSAPPLICATION(username=username, password=password,target=target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir=logs_dir)
@@ -81,6 +82,22 @@ class SHELL(cmd2.Cmd):
             self.cwd = args.path + "\\"
         else:
             self.cwd = args.path
+
+# ############
+# Optional OPSEC Toggles
+# ############
+
+    @cmd2.with_category(OPSEC)
+    def do_set_scriptauthor(self, arg):
+        """Set the author name for scripts created in this session.    set_scriptauthor (author name)"""
+        self.script.script_author = arg
+        logger.info(f"Script author set to {arg}")
+        
+    @cmd2.with_category(OPSEC)
+    def do_set_scriptname(self, arg):
+        """Set the name for scripts created in this session.           set_scriptname (script name)"""
+        self.script.script_name = arg
+        logger.info(f"Script name set to {arg}")
 
 # ############
 # Database Section
@@ -374,7 +391,7 @@ class SHELL(cmd2.Cmd):
             logger.info("Device ID not found. Decryptiong requires site server device ID")
         else:
             self.script.decrypt(blob=blob, device=self.device)
-    
+
     @cmd2.with_category(CE)
     def do_speak_to_the_manager(self, arg):
         """Dump policy credentials                          speak_to_the_manager"""
@@ -398,7 +415,7 @@ class SHELL(cmd2.Cmd):
 
 
 class CONSOLE:
-    def __init__(self, username=None, password=None, kerberos=False, domain=None, kdc=None, ip=None, debug=False, logs_dir=None, auser=None, apassword=None):
+    def __init__(self, username=None, password=None, kerberos=False, domain=None, kdc=None, ip=None, debug=False, logs_dir=None, auser=None, apassword=None, ps_transform=None):
         self.username = username
         self.password = password
         self.url = ip
@@ -409,6 +426,7 @@ class CONSOLE:
         self.logs_dir = logs_dir
         self.approve_user = auser
         self.approve_password = apassword
+        self.ps_transform = ps_transform
         
 
     def run(self):
@@ -467,7 +485,7 @@ class CONSOLE:
 
     def cli(self):
         #username, password, kerberos, domain, kdc, target, logs_dir, auser, apassword
-        cli = SHELL(self.username, self.password, self.kerberos, self.domain, self.kdc_host, self.url, self.logs_dir, self.approve_user, self.approve_password)
+        cli = SHELL(self.username, self.password, self.kerberos, self.domain, self.kdc_host, self.url, self.logs_dir, self.approve_user, self.approve_password, ps_transform=self.ps_transform)
         cli.cmdloop()
 
 if __name__ == '__main__':

--- a/lib/commands/admin.py
+++ b/lib/commands/admin.py
@@ -17,11 +17,12 @@ def main(
     kdc             : str   = typer.Option(None, '-dc', help="Target domain controller for Kerberos auth"),
     debug           : bool  = typer.Option(False, '-debug',help='Enable Verbose Logging'),
     auser           : str   = typer.Option(None, '-au', help="Optional script approval username"),
-    apassword       : str   = typer.Option(None, '-ap', help="Optional script approval password")
+    apassword       : str   = typer.Option(None, '-ap', help="Optional script approval password"),
+    ps_transform    : str   = typer.Option(None, '-pstransform', help="External command to obfuscate PowerShell scripts before execution. Use {input} and {output} placeholders for file-based tools (e.g. 'obfuscator -i {input} -o {output}'). Without placeholders, uses stdin/stdout piping.")
 ):
 
 
 
     logs_dir = init_logger(debug)
-    cmpivot = CONSOLE(username=username, password=password, kerberos=kerberos, domain=domain, kdc=kdc, ip=ip, debug=debug, logs_dir=logs_dir, auser=auser, apassword=apassword)
+    cmpivot = CONSOLE(username=username, password=password, kerberos=kerberos, domain=domain, kdc=kdc, ip=ip, debug=debug, logs_dir=logs_dir, auser=auser, apassword=apassword, ps_transform=ps_transform)
     cmpivot.run()

--- a/lib/scripts/pivot.py
+++ b/lib/scripts/pivot.py
@@ -5,7 +5,10 @@ import hashlib
 import json
 import math
 import os
+import shlex
 import sqlite3
+import subprocess
+import tempfile
 import time
 import uuid
 import xml.etree.ElementTree as ET
@@ -1695,7 +1698,7 @@ UserPrincipalName: {tb['UserPrincipalName'].to_string(index=False, header=False)
 
 class SMSSCRIPTS(AdminServiceClient):
 
-    def __init__(self, username, password, target,  kerberos, domain, kdcHost, logs_dir, auser, apassword):
+    def __init__(self, username, password, target,  kerberos, domain, kdcHost, logs_dir, auser, apassword, ps_transform=None):
         super().__init__(username, password, target,  kerberos, domain, kdcHost, logs_dir)
         self.approve_user = auser
         self.approve_password = apassword
@@ -1704,6 +1707,90 @@ class SMSSCRIPTS(AdminServiceClient):
         self.opid = ""
         self.guid = ""
         self.device = ""
+        self.ps_transform = ps_transform
+        self.script_name = "Updates"
+        self.script_author = ""
+
+    def _apply_transform(self, script_text):
+        cmd = self.ps_transform
+        has_input = '{input}' in cmd
+        has_output = '{output}' in cmd
+
+        logger.debug(f"[*] Applying PS transform: {cmd}")
+
+        try:
+            if not has_input and not has_output:
+                return self._transform_pipe(cmd, script_text)
+            else:
+                return self._transform_file(cmd, script_text, has_input, has_output)
+        except FileNotFoundError:
+            raise RuntimeError(f"PS transform command not found: {shlex.split(cmd)[0]}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("PS transform command timed out after 30 seconds")
+
+    def _transform_pipe(self, cmd, script_text):
+        result = subprocess.run(
+            shlex.split(cmd),
+            input=script_text,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"PS transform failed (exit {result.returncode}): {result.stderr.strip()}")
+        if not result.stdout.strip():
+            raise RuntimeError("PS transform command produced empty output")
+        
+        logger.debug(f"[+] PS transform applied")
+        return result.stdout
+
+    def _transform_file(self, cmd, script_text, has_input, has_output):
+        input_path = None
+        output_path = None
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.ps1', delete=False) as f:
+                f.write(script_text)
+                input_path = f.name
+
+            if has_output:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.ps1', delete=False) as f:
+                    output_path = f.name
+
+            updated_cmd = cmd
+            if has_input:
+                updated_cmd = updated_cmd.replace('{input}', shlex.quote(input_path))
+            if has_output:
+                updated_cmd = updated_cmd.replace('{output}', shlex.quote(output_path))
+
+            result = subprocess.run(
+                shlex.split(updated_cmd),
+                capture_output=True,
+                text=True,
+                timeout=30,
+                input=script_text if not has_input else None
+            )
+
+            if result.returncode != 0:
+                raise RuntimeError(f"PS transform failed (exit {result.returncode}): {result.stderr.strip()}")
+
+            if has_output:
+                with open(output_path, 'r') as f:
+                    transformed = f.read()
+            else:
+                transformed = result.stdout
+
+            if not transformed.strip():
+                raise RuntimeError("PS transform command produced empty output")
+
+            logger.debug(f"[+] PS transform applied")
+            return transformed
+        
+        finally:
+            if input_path and os.path.exists(input_path):
+                os.unlink(input_path)
+            if output_path and os.path.exists(output_path):
+                os.unlink(output_path)
 
     def run(self, device, optional_target=None):
         if optional_target:
@@ -1722,6 +1809,10 @@ Do-Delete
         with open(f"{self.script}", "r", encoding='utf-8') as f:
             file_content = f.read()
             file_content += cleanup
+            
+            if self.ps_transform:
+                file_content = self._apply_transform(file_content)
+            
             bom = codecs.BOM_UTF16_LE
             byte_array = bom + file_content.encode('utf-16-le')
             script_body = base64.b64encode(byte_array).decode('utf-8')
@@ -1759,9 +1850,9 @@ Do-Delete
                 script_body = self.read_script()
             self.guid = str(uuid.uuid4())
             body = {"ApprovalState": 3,
-            "ParamsDefinition": "", 
-            "ScriptName": "Updates",
-            "Author": "",
+            "ParamsDefinition": "",
+            "ScriptName": self.script_name,
+            "Author": self.script_author,
             "Script": f"{script_body}",
             "ScriptVersion": "1",
             "ScriptType": 0,
@@ -1773,7 +1864,7 @@ Do-Delete
             try:
                 r = self.http_post(url, json_data=body)
                 if r.status_code == 201:
-                        logger.info(f"[+] Updates script created successfully with GUID {self.guid}.")
+                        logger.info(f"[+] Script '{self.script_name}' created successfully with GUID {self.guid}.")
                         self.approve_script()
             except KeyboardInterrupt:
                 logger.info("Ctrl-C detected. Deleting script ... ")
@@ -1946,7 +2037,11 @@ function Do-Delete {
 }
 do-cat
 Do-Delete
-''' %file 
+''' %file
+
+        if self.ps_transform:
+            script = self._apply_transform(script)
+            
         bom = codecs.BOM_UTF16_LE
         byte_array = bom + script.encode('utf-16-le')
         script_body = base64.b64encode(byte_array).decode('utf-8')
@@ -1998,6 +2093,10 @@ Do-Delete
     Invoke-Decrypt -Hex %r
     Do-Delete
     ''' %blob
+    
+        if self.ps_transform:
+            script = self._apply_transform(script)
+            
         bom = codecs.BOM_UTF16_LE
         byte_array = bom + script.encode('utf-16-le')
         script_body = base64.b64encode(byte_array).decode('utf-8')
@@ -2063,6 +2162,10 @@ function Do-Delete {
 Invoke-DecryptEx -sessionKey %r -encryptedPwd %r
 Do-Delete
     '''%(session_key, encrypted_blob)
+    
+        if self.ps_transform:
+            script = self._apply_transform(script)
+            
         bom = codecs.BOM_UTF16_LE
         byte_array = bom + script.encode('utf-16-le')
         script_body = base64.b64encode(byte_array).decode('utf-8')


### PR DESCRIPTION
This PR has two new features to extend the opsec functionality of Powershell script execution.

## Powershell Hook

At the moment the Powershell scripts are embedded within SCCMHunter, meaning that changes to any embedded commands (cat, decrypt etc..) would need a modification of the src.

To introduce the ability to provide hooks for modifying Powershell as needed, I've added in the `-pstransform` option.

This option provides points to the path of another application which will be invoked and passed the proposed Powershell script during runtime. For example, we can start SCCMHunter with:

```
uv run ./sccmhunter.py admin -u test -p test -ip localhost -pstransform 'uv run /Users/test/tools/chameleon/chameleon.py -a -i {input} -o {output}'
```

Then when we invoke the admin command `decrypt`, the embedded decrypt Powershell script will first be written to tmp, and the path substituted for the `{input}` argument. SCCMHunter will launch chameleon.py, and wait for the tool to finish before reading the modified script from `{output}`. This script is then used rather than the embedded version.

Obviously the tools don't matter, you could throw an LLM in as the `pstransform` argument and achieve the same thing.

As well as {input} and {output} replacements, pstransform supports stdin/stdout (if no {input}/{output} placeholders are present). This means you can also include tooling which expects powershell to be piped in, and outputs to stdout modified powershell.

## OPSEC Admin Commands

Small tweak to the admin script commands, allowing script execution to specify the script Name and Author:

```
() (C:\) >> set_scriptauthor legitadmin
[12:27:28] INFO     Script author set to legitadmin
() (C:\) >> set_scriptname totallylegitscript.txt.ps1 
[12:27:44] INFO     Script name set to totallylegitscript.txt.ps1
```


