### PR TITLE
Fix SHELL.__init__ missing accache parameter

### DIFF
--- a/lib/attacks/admin.py
+++ b/lib/attacks/admin.py
@@ -21,7 +21,7 @@ class SHELL(cmd2.Cmd):
     hidden = ["alias", "help", "macro", "run_pyscript", "set", "shortcuts", "edit", "history", "quit", "run_script", "shell", "_relative_run_script", "eof"]
     
 
-    def __init__(self, username, password, kerberos, domain, kdc, target, logs_dir, auser, apassword, ps_transform=None):
+    def __init__(self, username, password, kerberos, domain, kdc, target, logs_dir, auser, apassword, accache=None, ps_transform=None):
         #initialize plugins
         self.pivot = CMPIVOT(username=username, password=password, target = target,  kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir = logs_dir)
         self.script = SMSSCRIPTS(username=username, password=password, target = target, kerberos=kerberos, domain=domain, kdcHost=kdc, logs_dir = logs_dir, auser=auser, apassword=apassword, accache=accache, ps_transform=ps_transform)


### PR DESCRIPTION
All of sudden I kept getting 401 access denied errors with valid tickets for SCCM Full Administrator. I used AI to identify and fix this bug. Confirmed by manually testing that I can log in with sccmhunter where it previously failed.

A merge between the approver-ccache PR b283793 and the PowerShell-hook PR b8fd4bf dropped the `accache` parameter from SHELL.__init__ while keeping CONSOLE.cli() passing self.approve_ccache positionally. That argument landed on the ps_transform slot, colliding with the ps_transform= kwarg and raising "TypeError: SHELL.__init__() got multiple values for argument 'ps_transform'" on every successful 200 from the AdminService.

Add `accache=None` to SHELL.__init__ in the slot the callsite expects.

