### PR TITLE
fix(ldap): handle blocked null SMB sessions in get_machine_name() for Kerberos auth

### DIFF
--- a/lib/ldap.py
+++ b/lib/ldap.py
@@ -27,8 +27,26 @@ def get_machine_name(domain_controller, domain):
     try:
         s.login('', '')
     except Exception:
-        if s.getServerName() == '':
+        srv_name = s.getServerName()
+        if srv_name == '':
+            # Anonymous/null SMB sessions are blocked on hardened DCs (STATUS_NOT_SUPPORTED).
+            # Fall back to resolving the NetBIOS name via reverse DNS,
+            # or derive it from the --dc-ip argument if DNS also fails.
+            if domain_controller:
+                try:
+                    import socket
+                    fqdn = socket.gethostbyaddr(domain_controller)[0]
+                    return fqdn.split('.')[0].upper()
+                except Exception:
+                    short = domain_controller.split('.')[0].upper()
+                    if short.isdigit():
+                        raise Exception(
+                            'Cannot resolve NetBIOS name for %s — null SMB sessions are blocked. '
+                            'Pass the DC FQDN (e.g. dc01.corp.local) via --dc-ip instead of a raw IP.' % domain_controller
+                        )
+                    return short
             raise Exception('Error while anonymous logging into %s' % domain)
+        return srv_name
     else:
         s.logoff()
     return s.getServerName()


### PR DESCRIPTION
## Problem
When using `-k` (Kerberos auth) against hardened DCs, `get_machine_name()`
attempts an anonymous SMB null session to resolve the DC's NetBIOS name.
On DCs with anonymous/null sessions disabled (common on Server 2022/2025),
this returns `STATUS_NOT_SUPPORTED (0xc00000bb)` and the tool crashes before
the LDAP bind is even attempted.

Error: `Error while anonymous logging into <domain>`

## Root Cause
`get_machine_name()` has no fallback when `getServerName()` returns empty
after a failed null login. The NetBIOS name is required to construct the
Kerberos target FQDN (`NETBIOSNAME.domain`).

## Fix
When the null session fails and `getServerName()` is empty:
1. Attempt reverse DNS (`socket.gethostbyaddr`) on the `--dc-ip` value
2. Fall back to parsing the short hostname from a FQDN passed to `--dc-ip`
3. Raise an actionable error message if only a raw IP is provided and DNS fails

## Testing
Verified against a Windows Server 2025 DC with:
- Anonymous SMB null sessions: **disabled**
- LDAP signing: **required**
- LDAP channel binding: **required**

Successful run: `python3 sccmhunter.py find -u user -p pass -d corp.local --dc-ip dc01.corp.local -k --ldaps`

## Notes
- Works alongside the existing `--signing` / `--channel-binding` / `--ldaps` flags
- No new dependencies introduced (`socket` is stdlib)
- Backward compatible — behavior unchanged when null sessions are allowed