### PR TITLE
Update requirements.txt with cmd2 package pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cmd2
+cmd2<4.0.0
 cryptography
 impacket
 ldap3 @ git+https://github.com/ly4k/ldap3


### PR DESCRIPTION
Temporary fix for issue #124 

Pins cm2 package version below 4.0.0 to fix commands breaking. 