### PR TITLE
fix: remove stray debug print(body) in sessionhunter's do_request

### DIFF
--- a/lib/scripts/pivot.py
+++ b/lib/scripts/pivot.py
@@ -245,7 +245,6 @@ class CMPIVOT(AdminServiceClient):
         endpoint = f"https://{self.target}/AdminService/v1.0/{self.endpoint}({self.device})/AdminService.RunCMPivot"
         try:
             r = self.http_post(endpoint, json_data=body)
-            print(body)
             if r.status_code == 200:
                 js0n = r.json()
                 if self.endpoint == "Collections":


### PR DESCRIPTION
Leftover debug statement dumps the raw CMPivot query body to stdout on every session/pivot request regardless of -debug.

Fixes #113