### PR TITLE
fix: use Cmd2ArgumentParser so the shell works on cmd2 >=4.0 (#124)

### DIFF
--- a/lib/parsers/parsers.py
+++ b/lib/parsers/parsers.py
@@ -1,15 +1,15 @@
-import argparse
+import cmd2
 
 class PARSERS:
 
 #cmd2 settings parsers
     def interact_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('device', action="store", help="Device ResourceID you want to interact with.")
         return parser
     
     def cd_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('path', action="store", help="path to change directories to. Ex: C:\\Users\\")
         return parser
 
@@ -17,32 +17,32 @@ class PARSERS:
 
 #database parsers
     def get_device_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('device', action="store", help="Query for device information")
         return parser
     
     def get_user_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('user', action="store", help="Query for user information")
         return parser
     
     def get_collection_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('collection_id', action="store", help="Query for collection information. Use a '*' to list all collections.")
         return parser
 
     def get_collection_members_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('collection_id', action="store", help="Query for all members of a collection.")
         return parser
 
     def get_puser_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('user', action="store", help="Find devices the target user is a primary user of.")
         return parser        
 
     def get_lastlogon_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('user', action="store", help="Find devices the target user recently logged into.")
         return parser    
     
@@ -50,7 +50,7 @@ class PARSERS:
     #Application Parser
     
     def application_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('-t', '--target', action='store', help="ResourceID to target for application deployment")
         parser.add_argument('-c', '--collection-type', action='store', help='Collection type to create for application deployment', choices=['user', 'device'])
         parser.add_argument('-p', '--path', action="store", help='Command or UNC path of the binary/script to execute. Ex: \\\\10.10.10.10\\payload.exe')
@@ -61,43 +61,43 @@ class PARSERS:
     
     #Powershell Script Parsers
     def cat_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('filename', action="store", help="Filename to display contents for.")
         return parser    
     
     def script_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('script', action="store", help="Script name or path to script")
         return parser    
 
     
     def delete_script_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('script_guid', action="store", help="GUID of target script to delete. Use list_scripts to get the GUID.")
         return parser    
     
     def get_script_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('script_guid', action="store", help="GUID of target script to view.")
         return parser   
     
     
     # cmpivot parsers
     def do_sessionhunter_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('user', action="store", help="Target user to find sessions for")
         return parser
     
     
     #add admin parsers
     def do_add_admin_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('-u', '--user', action='store', help='Target username to add as an admin', required=True)
         parser.add_argument('-s', '--sid', action='store', help="Target user's sid to add as an admin ", required=True)
         return parser
     
     def do_delete_admin_parser():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('user', action='store', help="Target admin username to remove")
         return parser
     
@@ -105,6 +105,6 @@ class PARSERS:
 
 
     def do_decrypt_parsers():
-        parser = argparse.ArgumentParser()
+        parser = cmd2.Cmd2ArgumentParser()
         parser.add_argument('blob', action='store', help="Encrypted blob to decrypt")
-    
+        return parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cmd2<4.0.0
+cmd2>=2.7.0
 cryptography
 impacket
 ldap3 @ git+https://github.com/ly4k/ldap3

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,33 @@
+import unittest
+
+import cmd2
+
+from lib.parsers.parsers import PARSERS
+
+
+def _parser_factories():
+    for name in dir(PARSERS):
+        if name.endswith("_parser") or name.endswith("_parsers"):
+            yield name, getattr(PARSERS, name)
+
+
+class ParserFactoryTests(unittest.TestCase):
+    """cmd2 >=4.0 raises a TypeError if a parser factory used with
+    @cmd2.with_argparser doesn't return a Cmd2ArgumentParser (see issue #124:
+    every factory here used to return a plain argparse.ArgumentParser).
+    These checks don't need cmd2 >=4.0 installed to catch a regression -- they
+    assert the same thing cmd2's own runtime check enforces."""
+
+    def test_every_parser_factory_returns_a_cmd2_argument_parser(self):
+        factories = list(_parser_factories())
+        self.assertGreater(len(factories), 0, "expected to find at least one *_parser factory")
+        for name, factory in factories:
+            parser = factory()
+            self.assertIsInstance(
+                parser, cmd2.Cmd2ArgumentParser,
+                f"PARSERS.{name}() must return a Cmd2ArgumentParser, got {type(parser).__name__}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## AI-assisted contribution — please read before reviewing

This patch was developed with AI assistance (Claude/Anthropic), directed and tested by me. I'm submitting it in good faith that it's correct, not as an expert assertion that it is. Please treat it with whatever scrutiny you'd want for an AI-assisted contribution.

## What this fixes

Closes #124. cmd2 ≥4.0 requires every parser factory used with `@cmd2.with_argparser` to return a `Cmd2ArgumentParser` (or subclass) — a plain `argparse.ArgumentParser` now raises a `TypeError` from cmd2's internal `_build_parser`. **All 17 parser factories in `lib/parsers/parsers.py` returned a plain `argparse.ArgumentParser`**, so on cmd2 ≥4.0 every single command in the interactive shell is broken, not just `get_device` — `get_user`, `get_collection`, `cd`, `interact`, `sessionhunter`, `application`, the script commands, the admin commands, all of it.

The fix is: switch all 17 factories to build a `cmd2.Cmd2ArgumentParser` instead. Also fixed `do_decrypt_parsers()`, which was missing its `return parser` entirely — currently dead code (not wired to any command), but a real bug sitting in the same file I was already touching.

**Also relaxed the `requirements.txt` pin.** It already had `cmd2<4.0.0` (the workaround mentioned in the issue), while `pyproject.toml` had no upper bound (`cmd2>=2.7.0`) — so which cmd2 version you got, and whether you hit this bug at all, depended on which of the two files your install path used. Now that the actual incompatibility is fixed, I aligned both to `cmd2>=2.7.0` with no upper bound, rather than leaving a workaround pin in place indefinitely for a bug that's now fixed. Happy to leave the pin in place instead if you'd rather be conservative here — this part is more of a judgment call than the rest of the fix.

## Reproduction: unpatched `main`, real cmd2 4.2.2, against a real lab

The dev environment here has cmd2 2.7.0 installed (which doesn't hit the bug), so I built a throwaway venv with real cmd2 4.2.2 to actually reproduce and verify this, rather than just trusting the traceback in the issue.

```
$ printf 'interact SMS00001\nget_device ps1-pss\nexit\n' | python sccmhunter.py admin -u domainjoin -p '<redacted>' -ip ps1-pss.mayyhem.com -d mayyhem.com -dc dc.mayyhem.com
SCCMHunter v2.0.0 by @unsigned_sh0rt
[!] Enter help for extra shell commands
TypeError: 'interact_parser' must return a 'Cmd2ArgumentParser' (or subclass).
Received: 'ArgumentParser'.

TypeError: 'get_device_parser' must return a 'Cmd2ArgumentParser' (or subclass).
Received: 'ArgumentParser'.
```

I also checked this wasn't limited to `get_device`/`interact` by instantiating the real `SHELL` class from `lib/attacks/admin` directly (no network) and running a representative set of commands under cmd2 4.2.2 — every single one failed with the same `TypeError`:

```
get_device mc          -> TypeError: 'get_device_parser' must return a 'Cmd2ArgumentParser' ...
get_user someuser       -> TypeError: 'get_user_parser' must return a 'Cmd2ArgumentParser' ...
get_collection SMS00001 -> TypeError: 'get_collection_parser' must return a 'Cmd2ArgumentParser' ...
cd C:\                  -> TypeError: 'cd_parser' must return a 'Cmd2ArgumentParser' ...
interact SMS00001       -> TypeError: 'interact_parser' must return a 'Cmd2ArgumentParser' ...
sessionhunter someuser  -> TypeError: 'do_sessionhunter_parser' must return a 'Cmd2ArgumentParser' ...
cat somefile.ps1        -> TypeError: 'cat_parser' must return a 'Cmd2ArgumentParser' ...
```

## After the fix: same lab, same cmd2 4.2.2 venv

```
$ printf 'interact SMS00001\nget_device ps1-pss\nexit\n' | python sccmhunter.py admin -u domainjoin -p '<redacted>' -ip ps1-pss.mayyhem.com -d mayyhem.com -dc dc.mayyhem.com
SCCMHunter v2.0.0 by @unsigned_sh0rt
[!] Enter help for extra shell commands
[*] Collecting device...
'value'
[-] Could not find device: ps1-pss
```

No `TypeError` — the command reaches the actual AdminService query and fails only on the lookup itself (`ps1-pss` isn't an exact match in this environment's `SMS_R_System`, unrelated to this fix). Same result for the representative command set above run against the real `SHELL` class: all 7 correctly proceed past parsing into their actual request logic (verified they reach real HTTP calls, either succeeding or failing on network/lookup grounds — never on the parser-type check).

## Regression / no-breakage checks

- `python -m unittest tests/test_parsers.py -v` — new test asserting every `*_parser`/`*_parsers` factory in `PARSERS` returns a `Cmd2ArgumentParser`. Confirmed it fails against the pre-fix code (`AssertionError: ... got ArgumentParser`) and passes after — this doesn't need cmd2 ≥4.0 installed to catch a future regression.
- `python -m py_compile lib/parsers/parsers.py` — clean.
- `git diff --check` — clean.
- Live-tested against a real lab on both cmd2 2.7.0 (this repo's normal venv, still works) and cmd2 4.2.2 (throwaway venv, now works) — no regression on the older version this project currently targets.
