### PR TITLE
fix: stop crashing on NETBIOS timeout during SMB profiling (#106)

### DIFF
--- a/lib/attacks/smb.py
+++ b/lib/attacks/smb.py
@@ -349,12 +349,14 @@ class SMB:
             if pxe_boot_servers:
                 self.smb_spider(conn, pxe_boot_servers)
             return signing, site_code, siteserv, distp, wsus, wdspxe, sccmpxe
-        except socket.error:
-            logger.info(socket.error)
-            return
         except Exception as e:
+            # A timed-out/dropped connection shouldn't be reported the same
+            # as a verified "not present" -- callers unpack this tuple
+            # unconditionally, so return an explicit unknown/failed state
+            # rather than None (which used to crash every caller) or False
+            # (which would misrepresent a timeout as a checked negative).
             logger.info(f"[-] {e}")
-            return
+            return None, 'None', None, None, None, None, None
 
     #if a distribution point is found with this directory
     #spider and search for pxeboot variables files

--- a/tests/test_smb_hunter.py
+++ b/tests/test_smb_hunter.py
@@ -1,0 +1,63 @@
+import socket
+import unittest
+from unittest.mock import MagicMock
+
+from lib.attacks.smb import SMB
+
+
+class SmbHunterFailureTests(unittest.TestCase):
+    """Issue #106: a NETBIOS timeout (or any other mid-session failure) used
+    to make smb_hunter() return None, which every caller unpacks into 7
+    variables unconditionally -- crashing with
+    'TypeError: cannot unpack non-iterable NoneType object'."""
+
+    def setUp(self):
+        self.smb = SMB.__new__(SMB)
+
+    def _assert_safe_unknown_tuple(self, conn):
+        result = self.smb.smb_hunter("dp01.example.test", conn)
+        # Must always be unpackable into exactly 7 values -- this is what
+        # every call site in check_siteservers/check_managementpoints/
+        # check_distributionpoints/check_computers does unconditionally.
+        signing, site_code, siteserv, distp, wsus, wdspxe, sccmpxe = result
+        self.assertIsNone(signing)
+        self.assertEqual(site_code, 'None')
+        self.assertIsNone(siteserv)
+        self.assertIsNone(distp)
+        self.assertIsNone(wsus)
+        self.assertIsNone(wdspxe)
+        self.assertIsNone(sccmpxe)
+
+    def test_netbios_timeout_does_not_crash_callers(self):
+        conn = MagicMock()
+        conn.isSigningRequired.side_effect = socket.timeout("The NETBIOS connection with the remote host timed out.")
+        self._assert_safe_unknown_tuple(conn)
+
+    def test_generic_socket_error_does_not_crash_callers(self):
+        conn = MagicMock()
+        conn.isSigningRequired.side_effect = socket.error("Connection reset by peer")
+        self._assert_safe_unknown_tuple(conn)
+
+    def test_unexpected_exception_does_not_crash_callers(self):
+        conn = MagicMock()
+        conn.listShares.side_effect = RuntimeError("something else entirely")
+        conn.isSigningRequired.return_value = False
+        self._assert_safe_unknown_tuple(conn)
+
+    def test_successful_query_is_unaffected(self):
+        conn = MagicMock()
+        conn.isSigningRequired.return_value = True
+        conn.listShares.return_value = []
+        result = self.smb.smb_hunter("dp01.example.test", conn)
+        signing, site_code, siteserv, distp, wsus, wdspxe, sccmpxe = result
+        self.assertTrue(signing)
+        self.assertEqual(site_code, 'None')
+        self.assertFalse(siteserv)
+        self.assertFalse(distp)
+        self.assertFalse(wsus)
+        self.assertFalse(wdspxe)
+        self.assertFalse(sccmpxe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## AI-assisted contribution — please read before reviewing

This patch was developed with AI assistance (Claude/Anthropic), directed and tested by me. I'm submitting it in good faith that it's correct, not as an expert assertion that it is. Please treat it with whatever scrutiny you'd want for an AI-assisted contribution.

## What this fixes

Closes #106. `smb_hunter()` already caught any exception mid-session (including a NETBIOS timeout) and logged it, but then did a bare `return` (implicit `None`). All 4 call sites (`check_siteservers`, `check_managementpoints`, `check_distributionpoints`, `check_computers`) unconditionally unpack its result into 7 variables, so a single unreachable/timed-out host anywhere in a profiling run crashed the whole `smb` command with `TypeError: cannot unpack non-iterable NoneType object` — matching both the traceback in the issue and [the reporter's own follow-up](https://github.com/garrettfoster13/sccmhunter/issues/106#issuecomment-3991057542) that this needs handling everywhere `self.smb_hunter` is used.

Rather than patching all 4 call sites individually, I fixed it at the source: `smb_hunter()` now always returns a well-formed 7-tuple. On failure it returns `None` for every boolean field and `'None'` for `site_code` (the "unknown" sentinel this file already uses elsewhere), instead of `False`. A timeout isn't the same thing as "checked and it's not present" — silently recording `False` for, say, `distp` (is this a distribution point?) could mislead an operator into thinking a role definitively isn't there when the connection just timed out.

While in there, I also collapsed the two `except` clauses — the `except socket.error:` branch had its own separate bug (`logger.info(socket.error)` logs the exception *class*, not the actual error message) and was otherwise functionally identical to the generic `except Exception` branch beneath it.

**Not included:** the reporter also suggested making the connection timeout configurable via a CLI flag. That's a reasonable separate feature request, but it's not what's crashing here (the crash happens on *any* smb_hunter failure, not specifically ones caused by an unconfigurable timeout value), so I left it out of this PR to keep it focused on the crash.

## Reproduction

A live mid-session NETBIOS timeout isn't something I could reliably trigger on demand against my lab's hosts (they all respond normally — the bug needs a host that accepts the connection but then hangs partway through). So instead of a live network reproduction, I wrote tests that exercise the real `smb_hunter()` method directly with a mocked connection whose calls raise the real exception types (`socket.timeout`, `socket.error`, and an arbitrary exception) at the exact point they'd occur mid-session — this is testing the actual method, not a re-implementation of it. Confirmed these fail against the pre-fix code with the exact reported error:

```
$ python -m unittest tests/test_smb_hunter.py -v   # run against unpatched main
...
TypeError: cannot unpack non-iterable NoneType object
FAILED (errors=3)
```

## After the fix

```
$ python -m unittest tests/test_smb_hunter.py -v
test_generic_socket_error_does_not_crash_callers ... ok
test_netbios_timeout_does_not_crash_callers ... ok
test_successful_query_is_unaffected ... ok
test_unexpected_exception_does_not_crash_callers ... ok

Ran 4 tests in 0.002s
OK
```

## Regression / no-breakage checks

- `python -m unittest tests/test_smb_hunter.py -v` — 4/4 pass; 3 of the 4 confirmed to fail against the pre-fix code with the exact reported `TypeError`, the 4th (happy path) passes both before and after.
- `python -m py_compile lib/attacks/smb.py` — clean.
- `git diff --check` — clean.
- Ran a full normal `smb` command against a real lab afterward (all hosts reachable, no timeouts) to confirm the success path is unaffected — same output shape as before the change, no crashes.
