### PR TITLE
fix: pass hostname string, not raw Entry, for resolved computer membe…

### DIFF
--- a/lib/attacks/find.py
+++ b/lib/attacks/find.py
@@ -324,7 +324,7 @@ class SCCMHUNTER:
                                     if (result['sAMAccountType']) == 805306369:
                                         hostname =  str(result['dNSHostname'])
                                         if hostname:
-                                            self.add_computer_to_db(result)
+                                            self.add_computer_to_db(hostname)
                                     if (result['sAMAccountType']) == 268435456:
                                         self.add_group_to_db(result)
                 except ldap3.core.exceptions.LDAPAttributeError as e:

--- a/tests/test_add_computer_to_db.py
+++ b/tests/test_add_computer_to_db.py
@@ -1,0 +1,73 @@
+import sqlite3
+import unittest
+from unittest.mock import MagicMock
+
+from lib.attacks.find import SCCMHUNTER
+
+
+class FakeEntry:
+    """Minimal stand-in for an ldap3 Entry -- dict-style access, but not a
+    plain str/dict, so passing one straight into a sqlite bind parameter
+    fails exactly like issue #97's 'Error binding parameter 1: type Entry
+    is not supported'."""
+
+    def __init__(self, attrs):
+        self._attrs = attrs
+
+    def __contains__(self, key):
+        return key in self._attrs
+
+    def __getitem__(self, key):
+        return self._attrs[key]
+
+
+def _make_sccmhunter():
+    hunter = SCCMHUNTER.__new__(SCCMHUNTER)
+    hunter.conn = sqlite3.connect(":memory:")
+    hunter.conn.executescript(
+        """
+        CREATE TABLE Groups(cn, name, sAMAAccontName, member, description);
+        CREATE TABLE Users(cn, name, sAMAAccontName, servicePrincipalName, description);
+        CREATE TABLE Computers(Hostname, SiteCode, SigningStatus, SiteServer, ManagementPoint, DistributionPoint, WSUS, MSSQL);
+        """
+    )
+    return hunter
+
+
+class ResolvedGroupMemberComputerTests(unittest.TestCase):
+    """Issue #97: with -resolve, a nested group member that's a computer was
+    passed to add_computer_to_db() as the raw ldap3 Entry instead of its
+    hostname string, crashing sqlite with
+    "Error binding parameter 1: type 'Entry' is not supported"."""
+
+    def setUp(self):
+        self.hunter = _make_sccmhunter()
+        self.hunter.resolve = True
+
+        group_entry = FakeEntry({
+            "sAMAccountType": 268435456,
+            "cn": "SCCM Admins",
+            "name": "SCCM Admins",
+            "sAMAccountName": "SCCM Admins",
+            "member": "",
+            "description": "",
+            "distinguishedname": "CN=SCCM Admins,DC=example,DC=test",
+        })
+        self.hunter.ldap_session = MagicMock()
+        self.hunter.ldap_session.entries = [group_entry]
+
+        resolved_computer = FakeEntry({
+            "sAMAccountType": 805306369,
+            "dNSHostname": "dp01.example.test",
+        })
+        self.hunter.recursive_resolution = MagicMock(return_value=[resolved_computer])
+
+    def test_resolved_computer_member_is_stored_by_hostname_string(self):
+        self.hunter.check_strings()
+
+        rows = self.hunter.conn.execute("SELECT Hostname FROM Computers").fetchall()
+        self.assertEqual(rows, [("dp01.example.test",)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## AI-assisted contribution — please read before reviewing

This patch was developed with AI assistance (Claude/Anthropic), directed and tested by me. I'm submitting it in good faith that it's correct, not as an expert assertion that it is. Please treat it with whatever scrutiny you'd want for an AI-assisted contribution.

## What this fixes

Closes #97. In `check_strings()`'s `-resolve` path, when a nested group member turns out to be a computer object, the code correctly extracts its hostname into a `hostname` variable... and then passes the *wrong variable* — the raw `ldap3` `Entry` (`result`) — into `add_computer_to_db()`, instead of the `hostname` string it just computed:

```python
if (result['sAMAccountType']) == 805306369:
    hostname =  str(result['dNSHostname'])
    if hostname:
        self.add_computer_to_db(result)   # <- bug: should be `hostname`
```

`add_computer_to_db()` expects a plain hostname string — every other call site in the file already passes one correctly (this is the only place that doesn't). Binding a raw `Entry` object as a sqlite parameter fails with `Error binding parameter 1: type 'Entry' is not supported`, matching the issue exactly, and matching the reporter's own observation that running *without* `-resolve` avoids the crash (the non-resolve branch a few lines above already does this correctly).

One-line fix: pass `hostname` instead of `result`.

## Reproduction

My lab's only nested-group membership had a user member, not a computer, so the buggy branch wasn't naturally reachable. I temporarily added an existing computer object as a member of that group (as a domain admin, purely to set up the test scenario — the actual reproduction below still runs as the same low-privileged account used throughout this project) to get a real nested **computer** group member, then reverted the membership change immediately after testing.

```
$ python sccmhunter.py find -u domainjoin -p '<redacted>' -d mayyhem.com -dc-ip dc.mayyhem.com -resolve -debug
...
[+] Found group: sccm_push_accounts
[+] Found user: sccm_push
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ .../lib/attacks/find.py:327 in check_strings                                 │
│    324    if (result['sAMAccountType']) == 805306369:                        │
│    325        hostname =  str(result['dNSHostname'])                         │
│    326        if hostname:                                                   │
│  ❱ 327            self.add_computer_to_db(result)                            │
│    328    if (result['sAMAccountType']) == 268435456:                        │
│                                                                                │
│ .../lib/attacks/find.py:407 in add_computer_to_db                            │
│  ❱ 407    cursor.execute('''select * from Computers where Hostname = ?''',... │
╰────────────────────────────────────────────────────────────────────────────────╯
ProgrammingError: Error binding parameter 1: type 'Entry' is not supported
```

Exact match to the reported error.

## After the fix: same lab, same nested computer group member

```
$ python sccmhunter.py find -u domainjoin -p '<redacted>' -d mayyhem.com -dc-ip dc.mayyhem.com -resolve -debug
...
[+] Found group: sccm_push_accounts
[+] Found user: sccm_push
...
Groups Table
| cn                  | member                                    |
| sccm_push_accounts  | CN=sccm_push,CN=Users,DC=mayyhem,DC=com   |
|                     | CN=PS1-DP,CN=Computers,DC=mayyhem,DC=com  |
```

No crash, and the `Computers` table confirms the resolved computer was stored correctly:

```
$ sqlite3 ~/.sccmhunter/logs/db/find.db "SELECT * FROM Computers WHERE Hostname LIKE '%ps1-dp%';"
ps1-dp.mayyhem.com||||||||
```

A clean hostname string, not a stringified `Entry` repr or anything else.

I also have unit tests (`tests/test_add_computer_to_db.py`) driving the real `check_strings()` method with a fake group entry and a fake resolved computer entry, confirmed to fail against pre-fix code with the same error shape (`type 'FakeEntry' is not supported`) and pass after — kept as durable regression coverage now that the live reproduction is done.

## Regression / no-breakage checks

- Live reproduction and fix confirmation against a real lab, as above.
- `python -m unittest tests/test_add_computer_to_db.py -v` — passes after the fix, confirmed to fail against pre-fix code with the exact reported error shape.
- `python -m py_compile lib/attacks/find.py` — clean.
- `git diff --check` — clean.
- Ran a normal `find -resolve` against the same lab with the group membership reverted to baseline afterward — no regression.
