### PR TITLE
Fix/ldap connection handling

### DIFF
--- a/lib/ldap.py
+++ b/lib/ldap.py
@@ -90,7 +90,7 @@ def init_ldap_connection(target, tls_version, domain, username, password, lmhash
     if use_channel_binding:
         channel_binding = dict(channel_binding=ldap3.TLS_CHANNEL_BINDING)
     if kerberos:
-        if channel_binding is True:
+        if use_channel_binding:
             logger.info("Kerberos auth + channel binding isn't supported yet.")
             sys.exit(1)
         logger.debug(f'[LDAP] Attempting Kerberos bind | target={target} port={port} ssl={use_ssl}')

--- a/lib/ldap.py
+++ b/lib/ldap.py
@@ -48,8 +48,10 @@ def get_machine_name(domain_controller, domain):
             raise Exception('Error while anonymous logging into %s' % domain)
         return srv_name
     else:
-        s.logoff()
-    return s.getServerName()
+        return s.getServerName()
+    finally:
+        s.close()
+
 
 def init_ldap_connection(target, tls_version, domain, username, password, lmhash, nthash, domain_controller, kerberos, hashes, aesKey, use_channel_binding, signing=False):
     if signing:

--- a/tests/test_smb_connection.py
+++ b/tests/test_smb_connection.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lib.ldap import get_machine_name
+
+class GetMachineNameSocketCleanupTests(unittest.TestCase):
+
+    def test_close_called_on_successful_login(self):
+        with patch('lib.ldap.SMBConnection') as mock_smb:
+            conn = MagicMock()
+            conn.login.side_effect = None
+            conn.getServerName.return_value = 'DC01'
+            mock_smb.return_value = conn
+
+            result = get_machine_name('10.0.0.1', 'lab.local')
+
+        self.assertEqual(result, 'DC01')
+        conn.close.assert_called_once()
+
+    def test_close_called_on_unsuccessful_login(self):
+        with patch('lib.ldap.SMBConnection') as mock_smb:
+            conn = MagicMock()
+            conn.login.side_effect = Exception('STATUS_ACCESS_DENIED')
+            conn.getServerName.return_value = 'DC02'
+            mock_smb.return_value = conn
+
+            result = get_machine_name('10.0.0.1', 'lab.local')
+
+        self.assertEqual(result, 'DC02')
+        conn.close.assert_called_once()
+
+    def test_close_called_on_successful_dns_fallback(self):
+        with patch('lib.ldap.SMBConnection') as mock_smb, patch('socket.gethostbyaddr') as mock_gethostbyaddr:
+            conn = MagicMock()
+            conn.login.side_effect = Exception('STATUS_ACCESS_DENIED')
+            conn.getServerName.return_value = ''
+            mock_smb.return_value = conn
+            mock_gethostbyaddr.return_value = ('dc03.lab.local', [], ['10.0.0.1'])
+            
+            result = get_machine_name('10.0.0.1', 'lab.local')
+
+        self.assertEqual(result, 'DC03') 
+        conn.close.assert_called_once()
+


### PR DESCRIPTION
Two bugs here:
- The Kerberos auth is checking if the dict `channel_binding` is True and a dict is not a boolean so this will fail. By switching to check the actual boolean `use_channel_binding` we are actually checking if it's true before continuing.
- SMB connection fails to call .close() on the sockets in _all_ of the paths, so it will leak open sockets for each connection made.  To fix it, I added a `finally` block to make sure sockets are closed regardless of what happens in the connection code, and moved return to the else block above it. Because `.close()` calls `.logoff()` that is now redundant so I removed it. I also wrote three tests to check successful/unsuccessful login and the successful DNS fallback path. I ran the new tests to confirm they would have picked up the bug.

I tested both bug fixes in my lab to confirm they work.