### PR TITLE
fix: add missing return statement in do_decrypt_parsers,

### DIFF
--- a/lib/parsers/parsers.py
+++ b/lib/parsers/parsers.py
@@ -107,4 +107,5 @@ class PARSERS:
     def do_decrypt_parsers():
         parser = argparse.ArgumentParser()
         parser.add_argument('blob', action='store', help="Encrypted blob to decrypt")
+        return parser
     

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,12 @@
+import unittest
+import argparse
+from lib.parsers.parsers import PARSERS
+
+class DoDecryptParsersTests(unittest.TestCase):
+
+    def test_do_decrypt_parsers(self):
+        parsers = PARSERS.do_decrypt_parsers()
+        result = parsers.parse_args(['some_test_blob'])
+
+        self.assertEqual(result.blob, 'some_test_blob')
+        self.assertIsInstance(parsers, argparse.ArgumentParser)


### PR DESCRIPTION
Found a missing return statement in the parser section. Fixed and added a test for it. No real consequence of this bug (yet) because the code is never referenced anywhere as far as I can tell.

FYI: doing this mostly to learn a big of Python and get familar with the code base.