### PR TITLE
fix: require -t, -tu and -ts for relay attack

### DIFF
--- a/lib/commands/relay.py
+++ b/lib/commands/relay.py
@@ -10,9 +10,9 @@ HELP = 'SCCM TAKEOVER-5 Attack'
 @app.callback(no_args_is_help=True, invoke_without_command=True)
 
 def main(
-    target          : str   = typer.Option(None, "-t",  help="Target SCCM SMS Provider IP or hostname. "),
-    target_user     : str   = typer.Option(None, "-tu",  help="Target username to add as SCCM admin. Ex: domain\\username"),
-    target_sid      : str   = typer.Option(None, "-ts",  help="Target user's SID to add as SCCM admin. Ex: S-1-5-21-123456789...."),
+    target          : str   = typer.Option(..., "-t",  help="Target SCCM SMS Provider IP or hostname. "),
+    target_user     : str   = typer.Option(..., "-tu",  help="Target username to add as SCCM admin. Ex: domain\\username"),
+    target_sid      : str   = typer.Option(..., "-ts",  help="Target user's SID to add as SCCM admin. Ex: S-1-5-21-123456789...."),
     interface       : str   = typer.Option("0.0.0.0", "-i",  help="Interface to listen on."),
     port            : int   = typer.Option(445, "-p",  help="Port to listen on."),
     timeout         : int   = typer.Option(5, "-to", help="Timeout value."),


### PR DESCRIPTION
TAKEOVER-5 requires you to specify a user and SID, but the code did not have these arguments set as required. This code is only used for TAKEOVER-5 currently, so it makes sense to make these arguments mandatory.

Before:
```
sccmhunter.py relay -p 1445

SCCMHunter v2.0.0 by @unsigned_sh0rt
[12:01:09] INFO     Targeting SCCM AdminService at https://None/AdminService/wmi/SMS_Admin                                                                                                                            
[12:01:09] INFO     Listening on 0.0.0.0:1445
```

After:
```
sccmhunter.py relay -p 1445

Try 'sccmhunter relay -h' for help.
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Missing option '-t'.                                                                                    │
╰────────────────────────────
```