### PR TITLE
fix: relay attack terminates prematurely and crashes on every attempt

### DIFF
--- a/lib/attacks/relay.py
+++ b/lib/attacks/relay.py
@@ -124,20 +124,19 @@ class SCCMHTTPSRelayClient(HTTPSRelayClient):
                     logger.debug(f"Response data:")
                     jprint(response_content)
                     SUCCESS = True
-                    return
+                    return (response_content, STATUS_SUCCESS)
                 if res.status == 401:
                     logger.info("Got unauthorized response from SCCM AdminService")
-                    SUCCESS = True
-                    return
+                    return (None, STATUS_ACCESS_DENIED)
                 else:
                     logger.info(f"Unexpected status code: {res.status}")
                     logger.debug(f"Response data: {response_data.decode('utf-8', errors='ignore')}")
-                    SUCCESS = True
-                    return
+                    return (None, STATUS_ACCESS_DENIED)
+            else:
+                return (None, STATUS_SUCCESS)
         except Exception as e:
             logger.info(f"Something went wrong:\n{e}")
-            SUCCESS = True
-            return
+            return (None, STATUS_ACCESS_DENIED)
         
         
 
@@ -177,6 +176,7 @@ class HTTPSCCMRELAY:
         """All taken from Certipy's relay implementation https://github.com/ly4k/Certipy"""
         logger.info("Listening on %s:%d" % (self.interface, self.port))
         logger.info("Waiting for incoming connections...")
+        logger.info(f"Will give up after {self.timeout}s with no successful attack.")
 
         self.server.start()
 
@@ -185,6 +185,9 @@ class HTTPSCCMRELAY:
         try:
             # Main loop with timeout check
             while not SUCCESS:                    
+                if time.time() - start_time > self.timeout:
+                    logger.info("Timeout reached, no successful attack.")
+                    break
                 time.sleep(0.1)
                 
         except KeyboardInterrupt:

--- a/lib/commands/relay.py
+++ b/lib/commands/relay.py
@@ -15,7 +15,7 @@ def main(
     target_sid      : str   = typer.Option(None, "-ts",  help="Target user's SID to add as SCCM admin. Ex: S-1-5-21-123456789...."),
     interface       : str   = typer.Option("0.0.0.0", "-i",  help="Interface to listen on."),
     port            : int   = typer.Option(445, "-p",  help="Port to listen on."),
-    timeout         : int   = typer.Option(5, "-to", help="Timeout value."),
+    timeout         : int   = typer.Option(300, "-to", help="Timeout value."),
     verbose         : bool  = typer.Option(False, "-v", help="Enable verbose logging.")
 ):
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import lib.attacks.relay as relay
+from lib.attacks.relay import SCCMHTTPSRelayClient
+from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED
+
+
+class SendAuthTests(unittest.TestCase):
+
+    def setUp(self):
+        relay.SUCCESS = False
+        relay.ELEVATED.clear()
+
+    def _make_client(self, status, body=b'{}'):
+        # Bypasses the real __init__ (needs a full impacket relay-server setup) --
+        # same trick the existing tests/test_add_computer_to_db.py already uses
+        # (SCCMHUNTER.__new__(SCCMHUNTER)), just manually setting what _sendAuth needs.
+        client = SCCMHTTPSRelayClient.__new__(SCCMHTTPSRelayClient)
+        res = MagicMock()
+        res.status = status
+        res.read.return_value = body
+        client.session = MagicMock()
+        client.session.getresponse.return_value = res
+        client.path = '/AdminService/wmi/SMS_Admin'
+        client.SCCM_relay = MagicMock()
+        client.SCCM_relay.target_user = 'testuser'
+        client.SCCM_relay.target_sid = '0xDEADBEEF'
+        return client
+
+    @patch('lib.attacks.relay.NTLMAuthChallengeResponse')
+    def test_already_elevated_sets_success_and_returns_success_tuple(self, mock_ntlm_response):
+        # _sendAuth parses a real NTLM AUTHENTICATE message to pull out domain/username.
+        # Mocking the parser itself avoids needing to construct a byte-perfect real one.
+        mock_ntlm_response.return_value.__getitem__.side_effect = {
+            'domain_name': 'DOMAIN'.encode('utf-16le'),
+            'user_name': 'attacker'.encode('utf-16le'),
+        }.__getitem__
+
+        relay.ELEVATED.append('DOMAIN\\attacker')
+        client = self._make_client(status=201)
+        result = client._sendAuth(b'\x00fake-token')
+
+        self.assertEqual(result, (None, STATUS_SUCCESS))
+        self.assertFalse(relay.SUCCESS)
+
+    @patch('lib.attacks.relay.NTLMAuthChallengeResponse')
+    def test_201_sets_success_and_returns_success_tuple(self, mock_ntlm_response):
+        # _sendAuth parses a real NTLM AUTHENTICATE message to pull out domain/username.
+        # Mocking the parser itself avoids needing to construct a byte-perfect real one.
+        mock_ntlm_response.return_value.__getitem__.side_effect = {
+            'domain_name': 'DOMAIN'.encode('utf-16le'),
+            'user_name': 'attacker'.encode('utf-16le'),
+        }.__getitem__
+
+        client = self._make_client(status=201)
+        result = client._sendAuth(b'\x00fake-token')
+
+        self.assertEqual(result, ('{}', STATUS_SUCCESS))
+        self.assertTrue(relay.SUCCESS)
+
+    @patch('lib.attacks.relay.NTLMAuthChallengeResponse')
+    def test_401_returns_unsuccessful_tuple(self, mock_ntlm_response):
+        mock_ntlm_response.return_value.__getitem__.side_effect = {
+            'domain_name': 'DOMAIN'.encode('utf-16le'),
+            'user_name': 'attacker'.encode('utf-16le'),
+        }.__getitem__
+
+        client = self._make_client(status=401)
+        result = client._sendAuth(b'\x00fake-token')
+
+        self.assertEqual(result, (None, STATUS_ACCESS_DENIED))
+        self.assertFalse(relay.SUCCESS)
+
+    @patch('lib.attacks.relay.NTLMAuthChallengeResponse')
+    def test_unexpected_status_code_returns_unsuccessful_tuple(self, mock_ntlm_response):
+        mock_ntlm_response.return_value.__getitem__.side_effect = {
+            'domain_name': 'DOMAIN'.encode('utf-16le'),
+            'user_name': 'attacker'.encode('utf-16le'),
+        }.__getitem__
+
+        client = self._make_client(status=500)
+        result = client._sendAuth(b'\x00fake-token')
+
+        self.assertEqual(result, (None, STATUS_ACCESS_DENIED))
+        self.assertFalse(relay.SUCCESS)
+    
+    @patch('lib.attacks.relay.NTLMAuthChallengeResponse')
+    def test_exception_returns_unsuccessful_tuple(self, mock_ntlm_response):
+        mock_ntlm_response.return_value.__getitem__.side_effect = {
+            'domain_name': 'DOMAIN'.encode('utf-16le'),
+            'user_name': 'attacker'.encode('utf-16le'),
+        }.__getitem__
+
+        client = self._make_client(status=200) # status irrelevant here since its never reached
+        client.session.request.side_effect = Exception("connection reset")
+        result = client._sendAuth(b'\x00fake-token')
+
+        self.assertEqual(result, (None, STATUS_ACCESS_DENIED))
+        self.assertFalse(relay.SUCCESS)
+    


### PR DESCRIPTION
In attacks/relay.py `SUCCESS` was set on every outcome (success, 401, unexpected status, exception), causing the listener to hard-exit after the first attempt regardless of result.

Separately, `_sendAuth` always returned a `None` instead of the `(response, errorCode)` tuple impacket's relay framework expects, crashing with a `TypeError` on every relayed auth.

I wrote tests to verify the bug, and made all the tests pass. 

Also, unrelated to the above, the `to/timeout` flag was dead in the main loop, so added the code that actually implements the timeout. Set the default timeout to 5 minutes / 300 seconds.

After I had done this, I wondered: was this relay code that implements TAKEOVER-5 just something you made pending the merge request to ntlmrelayx for supporting relaying to the adminservice api? Because i got started with looking at some bugs and then I realized maybe this is dead code you dont plan to have. Decided to submit this anyway since I did it mostly to learn more Python, so just do what you want with this PR.