### PR TITLE
fix: smb_hunter can crash the entire scan if a single host profiling fails

### DIFF
--- a/lib/attacks/smb.py
+++ b/lib/attacks/smb.py
@@ -349,12 +349,9 @@ class SMB:
             if pxe_boot_servers:
                 self.smb_spider(conn, pxe_boot_servers)
             return signing, site_code, siteserv, distp, wsus, wdspxe, sccmpxe
-        except socket.error:
-            logger.info(socket.error)
-            return
         except Exception as e:
             logger.info(f"[-] {e}")
-            return
+            return None, 'None', None, None, None, None, None
 
     #if a distribution point is found with this directory
     #spider and search for pxeboot variables files

--- a/tests/test_smb_hunter.py
+++ b/tests/test_smb_hunter.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import MagicMock
+
+from lib.attacks.smb import SMB
+
+class SmbHunterTests(unittest.TestCase):
+
+    def test_returns_safe_defaults_when_isSigningRequired_raises(self):
+            smb = SMB.__new__(SMB)
+            conn = MagicMock()
+            conn.isSigningRequired.side_effect = Exception("connection dropped")
+
+            result = smb.smb_hunter('somehost', conn)
+            
+            signing, site_code, sitesrv, distp, wsus, wdspxe, sccmpxe = result
+
+            self.assertEqual(signing, None)
+
+    def test_returns_safe_defaults_when_listShares_raises(self):
+            smb = SMB.__new__(SMB)
+            conn = MagicMock()
+            conn.listShares.side_effect = Exception("listing shares failed")
+
+            result = smb.smb_hunter('somehost', conn)
+            
+            signing, site_code, sitesrv, distp, wsus, wdspxe, sccmpxe = result
+
+            self.assertEqual(result, (None, 'None', None, None, None, None, None))
+
+
+    def test_returns_real_values_when_nothing_raises(self):
+        smb = SMB.__new__(SMB)
+        conn = MagicMock()
+        conn.isSigningRequired.return_value = True
+        conn.listShares.return_value = []
+
+        result = smb.smb_hunter('somehost', conn)
+
+        signing, site_code, siteserv, distp, wsus, wdspxe, sccmpxe = result
+        self.assertEqual(result, (True, 'None', False, False, False, False, False))


### PR DESCRIPTION
In `smb_hunter` I found that it returns `None` on four calls, and none of them check if the result contains `None` when unpacking the result into seven different variables. The consequence is that one host scan fails for any reason, the entire scan will crash and every host after it will not get profiled, not just the one that failed. I fixed it by making `smb_hunter` return a valid 7-tuple, using safe default values, on every exit path. I could not reproduce the issue in my lab, but mocked it out using a regression test, which confirmed to fail against the pre-fix code and pass against the fix.